### PR TITLE
Bump deprecation warnings

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,6 @@
 version = 1
 
-test_patterns = ["src/**/*.ts"]
+test_patterns = ["src/**/*.ts", tsconfig.json]
 
 exclude_patterns = ["src/**/*.test.ts", "examples/**", "scripts/**", "jest.setup.ts"]
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <a href="https://www.npmjs.com/package/upscaler"><img alt="npm" src="https://img.shields.io/npm/dw/upscaler" /></a>
 <a href="https://travis-ci.org/github/thekevinscott/UpscalerJS"><img alt="Travis" src="https://img.shields.io/travis/thekevinscott/upscalerjs" /></a>
 <a href="https://codecov.io/gh/thekevinscott/upscalerjs"><img alt="Codecov" src="https://img.shields.io/codecov/c/github/thekevinscott/upscalerjs" /></a>
-<a href="https://deepsource.io/gh/thekevinscott/UpscalerJS/?ref=repository-badge"><img alt="DeepSource" src="https://deepsource.io/gh/thekevinscott/UpscalerJS.svg/?label=active+issues&show_trend=true" /></a>
 <a href="https://github.com/thekevinscott/UpscalerJS/issues"><img alt="Github issues" src="https://img.shields.io/github/issues/thekevinscott/upscalerjs" /></a>
+<a href="https://deepsource.io/gh/thekevinscott/UpscalerJS/?ref=repository-badge"><img alt="DeepSource" src="https://deepsource.io/gh/thekevinscott/UpscalerJS.svg/?label=active+issues&show_trend=true" /></a>
 
 
 UpscalerJS is a tool for increasing image resolution in Javascript via a [Neural Network](https://github.com/thekevinscott/upscalerjs-models) up to 4x.

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "basic",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of basic usage of UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/comparisons/package.json
+++ b/examples/comparisons/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comparisons",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of the different models of UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/models/package.json
+++ b/examples/models/package.json
@@ -8,7 +8,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^4.0.2",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -31,5 +31,5 @@
       "last 1 safari version"
     ]
   },
-  "version": "0.7.6"
+  "version": "0.7.7"
 }

--- a/examples/patch-sizes/package.json
+++ b/examples/patch-sizes/package.json
@@ -10,7 +10,7 @@
     "react-input-range": "^1.3.0",
     "react-scripts": "^4.0.2",
     "tensor-as-base64": "^0.1.1",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "scripts": {
     "start": "PORT=1234 react-scripts start",
@@ -33,5 +33,5 @@
       "last 1 safari version"
     ]
   },
-  "version": "0.7.6"
+  "version": "0.7.7"
 }

--- a/examples/progress/package.json
+++ b/examples/progress/package.json
@@ -1,6 +1,6 @@
 {
   "name": "progress",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of upscale progress with UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/react-demo/package.json
+++ b/examples/react-demo/package.json
@@ -9,7 +9,7 @@
     "react-dom": "^16.13.1",
     "react-dropzone": "^11.0.2",
     "react-scripts": "^4.0.2",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "scripts": {
     "start": "react-scripts start",
@@ -32,5 +32,5 @@
       "last 1 safari version"
     ]
   },
-  "version": "0.7.6"
+  "version": "0.7.7"
 }

--- a/examples/tensor/package.json
+++ b/examples/tensor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tensor",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of basic usage of UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/upload/package.json
+++ b/examples/upload/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upload",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of uploading an image to UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/warmup/package.json
+++ b/examples/warmup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warmup",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of warming up UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/webcam/package.json
+++ b/examples/webcam/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webcam",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of webcam usage of UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   },
   "browserslist": {
     "production": [

--- a/examples/webworker/package.json
+++ b/examples/webworker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webworker",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Demonstration of webworker integration with UpscalerJS",
   "main": "index.js",
   "scripts": {
@@ -28,6 +28,6 @@
   "dependencies": {
     "@tensorflow/tfjs": "2.8.6",
     "tensor-as-base64": "^0.1.1",
-    "upscaler": "0.7.6"
+    "upscaler": "0.7.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upscaler",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Increase image resolution with a Neural Network",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/loadModel.test.ts
+++ b/src/loadModel.test.ts
@@ -2,14 +2,43 @@ import loadModel, {
   prepareModelDefinitions,
   getModelDefinition,
   getModelDescription,
+  warnDeprecatedModel,
+  checkDeprecatedModels,
 } from './loadModel';
 import * as models from './models';
 import * as tf from '@tensorflow/tfjs';
+import * as utils from './utils';
 jest.mock('./models');
 jest.mock('@tensorflow/tfjs');
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  warn: jest.fn(),
+}));
 
 const mockModels = (obj: { [index: string]: any }) =>
   Object.entries(obj).forEach(([key, val]) => ((models as any)[key] = val));
+
+describe('checkDeprecatedModels', () => {
+  it('does not report if not a deprecated model', () => {
+    checkDeprecatedModels({}, 'foo');
+    expect(utils.warn).not.toBeCalled();
+  });
+
+  it('does report if a deprecated model', () => {
+    checkDeprecatedModels({
+      foo: ['foo', 'bar', 'baz'],
+    }, 'foo');
+    expect(utils.warn).toBeCalled();
+  });
+});
+
+describe('warnDeprecatedModel', () => {
+  it('gives a warning message', () => {
+    const args: [string, string, string] = ['psnr', 'idealo/psnr-small', '0.8.0'];
+    warnDeprecatedModel(...args);
+    expect(utils.warn).toBeCalledWith(expect.arrayContaining([expect.stringContaining('psnr')]));
+  })
+});
 
 describe('getModelDescription', () => {
   afterEach(() => {
@@ -45,7 +74,7 @@ describe('getModelDescription', () => {
   });
 });
 
-describe('getModelDefinitions', () => {
+describe('getModelDefinition', () => {
   afterEach(() => {
     (global.fetch as any).mockClear();
     delete global.fetch;

--- a/src/loadModel.test.ts
+++ b/src/loadModel.test.ts
@@ -11,7 +11,7 @@ import * as utils from './utils';
 jest.mock('./models');
 jest.mock('@tensorflow/tfjs');
 jest.mock('./utils', () => ({
-  ...jest.requireActual('./utils'),
+  ...(jest.requireActual('./utils') as any),
   warn: jest.fn(),
 }));
 
@@ -25,19 +25,28 @@ describe('checkDeprecatedModels', () => {
   });
 
   it('does report if a deprecated model', () => {
-    checkDeprecatedModels({
-      foo: ['foo', 'bar', 'baz'],
-    }, 'foo');
+    checkDeprecatedModels(
+      {
+        foo: ['foo', 'bar', 'baz'],
+      },
+      'foo',
+    );
     expect(utils.warn).toBeCalled();
   });
 });
 
 describe('warnDeprecatedModel', () => {
   it('gives a warning message', () => {
-    const args: [string, string, string] = ['psnr', 'idealo/psnr-small', '0.8.0'];
+    const args: [string, string, string] = [
+      'psnr',
+      'idealo/psnr-small',
+      '0.8.0',
+    ];
     warnDeprecatedModel(...args);
-    expect(utils.warn).toBeCalledWith(expect.arrayContaining([expect.stringContaining('psnr')]));
-  })
+    expect(utils.warn).toBeCalledWith(
+      expect.arrayContaining([expect.stringContaining('psnr')]),
+    );
+  });
 });
 
 describe('getModelDescription', () => {

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -18,18 +18,19 @@ const warnDeprecatedModel = (
     `Please switch to the following key: ${nextKey}`,
   ]);
 
+const DEPRECATION_WARNINGS: {
+  [index: string]: [string, string, string];
+} = {
+  'div2k-2x': ['div2k-2x', 'div2k/rdn-C3-D10-G64-G064-x2', '0.8.0'],
+  'div2k-3x': ['div2k-3x', 'div2k/rdn-C3-D10-G64-G064-x3', '0.8.0'],
+  'div2k-4x': ['div2k-4x', 'div2k/rdn-C3-D10-G64-G064-x4', '0.8.0'],
+  'psnr': ['psnr', 'idealo/psnr-small', '0.8.0'],
+};
+
 const checkDeprecatedModels = (model: string) => {
-  if (model === 'div2k-2x') {
-    warnDeprecatedModel('div2k-2x', 'div2k/rdn-C3-D10-G64-G064-x2', '0.6.0');
-  }
-  if (model === 'div2k-3x') {
-    warnDeprecatedModel('div2k-3x', 'div2k/rdn-C3-D10-G64-G064-x3', '0.6.0');
-  }
-  if (model === 'div2k-4x') {
-    warnDeprecatedModel('div2k-4x', 'div2k/rdn-C3-D10-G64-G064-x4', '0.6.0');
-  }
-  if (model === 'psnr') {
-    warnDeprecatedModel('psnr', 'idealo/psnr-small', '0.6.0');
+  const deprecationWarning = DEPRECATION_WARNINGS[model];
+  if (deprecationWarning) {
+    warnDeprecatedModel(...deprecationWarning);
   }
 };
 

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -29,7 +29,10 @@ const DEPRECATION_WARNINGS: DeprecationWarnings = {
   psnr: ['psnr', 'idealo/psnr-small', '0.8.0'],
 };
 
-export const checkDeprecatedModels = (warnings: DeprecationWarnings, model: string) => {
+export const checkDeprecatedModels = (
+  warnings: DeprecationWarnings,
+  model: string,
+) => {
   const deprecationWarning = warnings[model];
   if (deprecationWarning) {
     warnDeprecatedModel(...deprecationWarning);

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -24,7 +24,7 @@ const DEPRECATION_WARNINGS: {
   'div2k-2x': ['div2k-2x', 'div2k/rdn-C3-D10-G64-G064-x2', '0.8.0'],
   'div2k-3x': ['div2k-3x', 'div2k/rdn-C3-D10-G64-G064-x3', '0.8.0'],
   'div2k-4x': ['div2k-4x', 'div2k/rdn-C3-D10-G64-G064-x4', '0.8.0'],
-  'psnr': ['psnr', 'idealo/psnr-small', '0.8.0'],
+  psnr: ['psnr', 'idealo/psnr-small', '0.8.0'],
 };
 
 const checkDeprecatedModels = (model: string) => {

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -8,7 +8,7 @@ const ERROR_URL_EXPLICIT_SCALE_REQUIRED =
 const ERROR_URL_EXPLICIT_SCALE_DISALLOWED =
   'https://thekevinscott.github.io/UpscalerJS/#/?id=you-are-requesting-the-pretrained-model-but-are-providing-an-explicit-scale';
 
-const warnDeprecatedModel = (
+export const warnDeprecatedModel = (
   key: string,
   nextKey: string,
   expirationVersion: string,
@@ -18,17 +18,19 @@ const warnDeprecatedModel = (
     `Please switch to the following key: ${nextKey}`,
   ]);
 
-const DEPRECATION_WARNINGS: {
+export interface DeprecationWarnings {
   [index: string]: [string, string, string];
-} = {
+}
+
+const DEPRECATION_WARNINGS: DeprecationWarnings = {
   'div2k-2x': ['div2k-2x', 'div2k/rdn-C3-D10-G64-G064-x2', '0.8.0'],
   'div2k-3x': ['div2k-3x', 'div2k/rdn-C3-D10-G64-G064-x3', '0.8.0'],
   'div2k-4x': ['div2k-4x', 'div2k/rdn-C3-D10-G64-G064-x4', '0.8.0'],
   psnr: ['psnr', 'idealo/psnr-small', '0.8.0'],
 };
 
-const checkDeprecatedModels = (model: string) => {
-  const deprecationWarning = DEPRECATION_WARNINGS[model];
+export const checkDeprecatedModels = (warnings: DeprecationWarnings, model: string) => {
+  const deprecationWarning = warnings[model];
   if (deprecationWarning) {
     warnDeprecatedModel(...deprecationWarning);
   }
@@ -41,7 +43,7 @@ export const getModelDefinition = ({
   if (model in MODELS) {
     const modelDefinition = MODELS[model];
     if (modelDefinition.deprecated) {
-      checkDeprecatedModels(model);
+      checkDeprecatedModels(DEPRECATION_WARNINGS, model);
     }
     if (scale) {
       throw new Error(

--- a/src/warmup.test.ts
+++ b/src/warmup.test.ts
@@ -16,7 +16,6 @@ const getFakeModel = () => {
 };
 
 describe('Warmup', () => {
-  
   it('throws if given an invalid size', async () => {
     const fakeModel = getFakeModel();
     const model = new Promise<{


### PR DESCRIPTION
Existing deprecated models were not removed at version `0.6.0` (nor at version `0.7.0`). Since people may still be relying on the old keys, let's bump the deprecation warnings to remove them at the next point release (`0.8.0`).