### PR TITLE
Hotfix - remove the @latest from the CDN path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.17](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.12...v0.8.17) (2021-03-15)
+
+**Note:** Version bump only for package UpscalerJS
+
+
+
+
+
 ## [0.8.16](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.15...v0.8.16) (2021-03-15)
 
 **Note:** Version bump only for package UpscalerJS

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "lerna": "2.2.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "0.8.16"
+  "version": "0.8.17"
 }

--- a/packages/models/CHANGELOG.md
+++ b/packages/models/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.17](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.12...v0.8.17) (2021-03-15)
+
+**Note:** Version bump only for package @upscalerjs/models
+
+
+
+
+
 ## [0.8.16](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.15...v0.8.16) (2021-03-15)
 
 **Note:** Version bump only for package @upscalerjs/models

--- a/packages/models/package.json
+++ b/packages/models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@upscalerjs/models",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Models for UpscalerJS",
   "keywords": [
     "image super resolution",

--- a/packages/upscalerjs/CHANGELOG.md
+++ b/packages/upscalerjs/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.8.17](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.12...v0.8.17) (2021-03-15)
+
+**Note:** Version bump only for package upscaler
+
+
+
+
+
 ## [0.8.16](https://github.com/thekevinscott/UpscalerJS/compare/v0.8.15...v0.8.16) (2021-03-15)
 
 **Note:** Version bump only for package upscaler

--- a/packages/upscalerjs/package.json
+++ b/packages/upscalerjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upscaler",
-  "version": "0.8.16",
+  "version": "0.8.17",
   "description": "Increase image resolution with a Neural Network",
   "main": "dist/cjs/index.js",
   "module": "dist/esnext/index.js",

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -23,10 +23,10 @@ export const isFourDimensionalTensor = (
 const MODEL_DIR = 'models';
 
 export const buildURL = (modelFolder: string) =>
-  `${ROOT}@latest/${MODEL_DIR}/${modelFolder}/model.json`;
+  `${ROOT}/${MODEL_DIR}/${modelFolder}/model.json`;
 
 export const buildConfigURL = (modelFolder: string) =>
-  `${ROOT}@latest/${MODEL_DIR}/${modelFolder}/config.json`;
+  `${ROOT}/${MODEL_DIR}/${modelFolder}/config.json`;
 
 export const warn = (msg: string | string[]) => {
   if (Array.isArray(msg)) {


### PR DESCRIPTION
My bad - CDN path should not have `@latest` in it anymore.