### PR TITLE
Revert to only running actions on PR target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,9 @@ jobs:
       - name: 'Running test'
         run: yarn test:unit
 
+      - name: 'Move coverage to root'
+        run: mv packages/upscalerjs/coverage ./coverage
+
   integration-browser:
     name: 'Integration / Browser'
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,8 @@
 name: 'Tests'
-on: [pull_request, pull_request_target]
+on:
+  pull_request_target:
+    types: [opened]
+
 jobs:
   unit:
     name: 'Unit'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   unit:
-    name: 'Unit with Cov'
+    name: 'Unit'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   unit:
-    name: 'Unit'
+    name: 'Unit with Cov'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout repository'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,9 @@
 ignore:
+  - ".github"
+  - "assert"
   - "dist"
   - "examples"
   - "docs"
   - "scripts"
+  - "test"
+  - "packages/test-scaffolding"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "bootstrap": "yarn lerna bootstrap --hoist",
     "build": "yarn lerna run build",
     "server": "yarn serve -p 8000 packages/upscalerjs/test/lib/webpack-bundler/dist/",
-    "test:unit": "yarn lerna run test:unit",
+    "test:unit": "jest --config packages/upscalerjs/jestconfig.json",
     "test:integration:browser": "jest test/integration --config test/jestconfig.json --detectOpenHandles",
     "test:startTestServer": "node test/lib/startServer.js"
   },

--- a/packages/upscalerjs/package.json
+++ b/packages/upscalerjs/package.json
@@ -36,8 +36,7 @@
     "build:es5": "tsc --module amd --moduleResolution node --target es5 --outFile dist/es5/index.js",
     "build:umd": "yarn build:es5 && rollup dist/es5/index.js --format umd --name Upscaler --output.file dist/umd/upscaler.js && rimraf dist/es5",
     "build:umd:min": "cd dist/umd && uglifyjs --compress --mangle --source-map --comments --o upscaler.min.js -- upscaler.js && gzip upscaler.min.js -c > upscaler.min.js.gz",
-    "watch": "rimraf dist && tsc --watch --skipLibCheck",
-    "test:unit": "jest --config jestconfig.json"
+    "watch": "rimraf dist && tsc --watch --skipLibCheck"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
In #60 we ran into some issues where `pull_request` and `pull_request_target` were both being called. I _think_ we only need `pull_request_target`; this PR will check that.