### PR TITLE
Leverage tf.browser.fromPixels on input

### DIFF
--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -1,25 +1,18 @@
 import { tf } from './dependencies.generated';
 import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString } from './utils';
 
-export const getUnknownError = (input: any) => new Error(
+export const getInvalidTensorError = (input: tf.Tensor) => new Error(
     [
-      `Unknown input provided to loadImage that cannot be processed: ${JSON.stringify(input)}`,
-      `Can only handle a string pointing to a valid image resource, an HTMLImageElement element,`,
-      `or a 3 or 4 rank tensor.`,
+      `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
+      'Only 3 or 4 rank tensors are supported.',
     ].join(' '),
   );
 
-  export const getInvalidTensorError = (input: tf.Tensor) => new Error(
-      [
-        `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
-        'Only 3 or 4 rank tensors are supported.',
-      ].join(' '),
-    );
-
 // Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
 type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
+export type ImageInput = tf.Tensor3D | tf.Tensor4D | string | FromPixelsInputs;
 export const getImageAsPixels = async (
-  pixels: string | FromPixelsInputs,
+  pixels: ImageInput,
 ): Promise<{
   tensor: tf.Tensor4D;
   canDispose: boolean;

--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -1,5 +1,5 @@
 import { tf } from './dependencies.generated';
-import { isHTMLImageElement, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor } from './utils';
+import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString } from './utils';
 
 export const getUnknownError = (input: any) => new Error(
     [
@@ -16,12 +16,32 @@ export const getUnknownError = (input: any) => new Error(
       ].join(' '),
     );
 
+// Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
+type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
 export const getImageAsPixels = async (
-  pixels: string | HTMLImageElement | tf.Tensor,
+  pixels: string | FromPixelsInputs,
 ): Promise<{
   tensor: tf.Tensor4D;
-  type: 'string' | 'HTMLImageElement' | 'tensor';
+  canDispose: boolean;
 }> => {
+  if (isTensor(pixels)) {
+    if (isFourDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels,
+        canDispose: false,
+      };
+    }
+
+    if (isThreeDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels.expandDims(0),
+        canDispose: true,
+      };
+    }
+
+    throw getInvalidTensorError(pixels);
+  }
+
   if (isString(pixels)) {
     const img = await new Promise<HTMLImageElement>((resolve, reject) => {
       const img = new Image();
@@ -30,36 +50,36 @@ export const getImageAsPixels = async (
       img.onload = () => resolve(img);
       img.onerror = reject;
     });
-    return {
-      tensor: tf.browser.fromPixels(img).expandDims(0) as tf.Tensor4D,
-      type: 'string',
-    };
-  }
 
-  if (isHTMLImageElement(pixels)) {
-    return {
-      tensor: tf.browser.fromPixels(pixels).expandDims(0) as tf.Tensor4D,
-      type: 'HTMLImageElement',
-    };
-  }
+    const tensor = tf.browser.fromPixels(img);
 
-  if (isTensor(pixels)) {
-    if (isFourDimensionalTensor(pixels)) {
+    if (isFourDimensionalTensor(tensor)) {
       return {
-        tensor: pixels,
-        type: 'tensor',
+        tensor,
+        canDispose: true,
       };
     }
 
-    if (isThreeDimensionalTensor(pixels)) {
+    if (isThreeDimensionalTensor(tensor)) {
       return {
-        tensor: pixels.expandDims(0) as tf.Tensor4D,
-        type: 'tensor',
+        tensor: tensor.expandDims(0),
+        canDispose: true,
       };
     }
 
-    throw getInvalidTensorError(pixels);
+    throw getInvalidTensorError(tensor);
   }
 
-  throw getUnknownError(pixels);
+  const tensor = tf.browser.fromPixels(pixels);
+  if (isThreeDimensionalTensor(tensor)) {
+    return {
+      tensor: tensor.expandDims(0),
+      canDispose: true,
+    };
+  }
+
+  return {
+    tensor,
+    canDispose: true,
+  };
 };

--- a/packages/upscalerjs/src/image.generated.ts
+++ b/packages/upscalerjs/src/image.generated.ts
@@ -1,25 +1,18 @@
 import { tf } from './dependencies.generated';
 import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString } from './utils';
 
-export const getUnknownError = (input: any) => new Error(
+export const getInvalidTensorError = (input: tf.Tensor) => new Error(
     [
-      `Unknown input provided to loadImage that cannot be processed: ${JSON.stringify(input)}`,
-      `Can only handle a string pointing to a valid image resource, an HTMLImageElement element,`,
-      `or a 3 or 4 rank tensor.`,
+      `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
+      'Only 3 or 4 rank tensors are supported.',
     ].join(' '),
   );
 
-  export const getInvalidTensorError = (input: tf.Tensor) => new Error(
-      [
-        `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
-        'Only 3 or 4 rank tensors are supported.',
-      ].join(' '),
-    );
-
 // Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
 type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
+export type ImageInput = tf.Tensor3D | tf.Tensor4D | string | FromPixelsInputs;
 export const getImageAsPixels = async (
-  pixels: string | FromPixelsInputs,
+  pixels: ImageInput,
 ): Promise<{
   tensor: tf.Tensor4D;
   canDispose: boolean;

--- a/packages/upscalerjs/src/image.generated.ts
+++ b/packages/upscalerjs/src/image.generated.ts
@@ -1,5 +1,5 @@
 import { tf } from './dependencies.generated';
-import { isHTMLImageElement, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor } from './utils';
+import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString } from './utils';
 
 export const getUnknownError = (input: any) => new Error(
     [
@@ -17,11 +17,29 @@ export const getUnknownError = (input: any) => new Error(
     );
 
 export const getImageAsPixels = async (
-  pixels: string | HTMLImageElement | tf.Tensor,
+  pixels: string | tf.FromPixelsInputs,
 ): Promise<{
   tensor: tf.Tensor4D;
-  type: 'string' | 'HTMLImageElement' | 'tensor';
+  canDispose: boolean;
 }> => {
+  if (isTensor(pixels)) {
+    if (isFourDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels,
+        canDispose: false,
+      };
+    }
+
+    if (isThreeDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels.expandDims(0),
+        canDispose: true,
+      };
+    }
+
+    throw getInvalidTensorError(pixels);
+  }
+
   if (isString(pixels)) {
     const img = await new Promise<HTMLImageElement>((resolve, reject) => {
       const img = new Image();
@@ -30,36 +48,36 @@ export const getImageAsPixels = async (
       img.onload = () => resolve(img);
       img.onerror = reject;
     });
-    return {
-      tensor: tf.browser.fromPixels(img).expandDims(0) as tf.Tensor4D,
-      type: 'string',
-    };
-  }
 
-  if (isHTMLImageElement(pixels)) {
-    return {
-      tensor: tf.browser.fromPixels(pixels).expandDims(0) as tf.Tensor4D,
-      type: 'HTMLImageElement',
-    };
-  }
+    const tensor = tf.browser.fromPixels(img);
 
-  if (isTensor(pixels)) {
-    if (isFourDimensionalTensor(pixels)) {
+    if (isFourDimensionalTensor(tensor)) {
       return {
-        tensor: pixels,
-        type: 'tensor',
+        tensor,
+        canDispose: true,
       };
     }
 
-    if (isThreeDimensionalTensor(pixels)) {
+    if (isThreeDimensionalTensor(tensor)) {
       return {
-        tensor: pixels.expandDims(0) as tf.Tensor4D,
-        type: 'tensor',
+        tensor: tensor.expandDims(0),
+        canDispose: true,
       };
     }
 
-    throw getInvalidTensorError(pixels);
+    throw getInvalidTensorError(tensor);
   }
 
-  throw getUnknownError(pixels);
+  const tensor = tf.browser.fromPixels(pixels);
+  if (isThreeDimensionalTensor(tensor)) {
+    return {
+      tensor: tensor.expandDims(0),
+      canDispose: true,
+    };
+  }
+
+  return {
+    tensor,
+    canDispose: true,
+  };
 };

--- a/packages/upscalerjs/src/image.generated.ts
+++ b/packages/upscalerjs/src/image.generated.ts
@@ -16,8 +16,10 @@ export const getUnknownError = (input: any) => new Error(
       ].join(' '),
     );
 
+// Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
+type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
 export const getImageAsPixels = async (
-  pixels: string | tf.FromPixelsInputs,
+  pixels: string | FromPixelsInputs,
 ): Promise<{
   tensor: tf.Tensor4D;
   canDispose: boolean;

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -1,27 +1,40 @@
 import { tf } from './dependencies.generated';
-import { isHTMLImageElement, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor } from './utils';
+import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString } from './utils';
 
-export const getUnknownError = (input: any) => new Error(
+export const getInvalidTensorError = (input: tf.Tensor) => new Error(
     [
-      `Unknown input provided to loadImage that cannot be processed: ${JSON.stringify(input)}`,
-      `Can only handle a string pointing to a valid image resource, an HTMLImageElement element,`,
-      `or a 3 or 4 rank tensor.`,
+      `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
+      'Only 3 or 4 rank tensors are supported.',
     ].join(' '),
   );
 
-  export const getInvalidTensorError = (input: tf.Tensor) => new Error(
-      [
-        `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
-        'Only 3 or 4 rank tensors are supported.',
-      ].join(' '),
-    );
-
+// Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
+type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
+export type ImageInput = tf.Tensor3D | tf.Tensor4D | string | FromPixelsInputs;
 export const getImageAsPixels = async (
-  pixels: string | HTMLImageElement | tf.Tensor,
+  pixels: ImageInput,
 ): Promise<{
   tensor: tf.Tensor4D;
-  type: 'string' | 'HTMLImageElement' | 'tensor';
+  canDispose: boolean;
 }> => {
+  if (isTensor(pixels)) {
+    if (isFourDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels,
+        canDispose: false,
+      };
+    }
+
+    if (isThreeDimensionalTensor(pixels)) {
+      return {
+        tensor: pixels.expandDims(0),
+        canDispose: true,
+      };
+    }
+
+    throw getInvalidTensorError(pixels);
+  }
+
   if (isString(pixels)) {
     const img = await new Promise<HTMLImageElement>((resolve, reject) => {
       const img = new Image();
@@ -30,36 +43,36 @@ export const getImageAsPixels = async (
       img.onload = () => resolve(img);
       img.onerror = reject;
     });
-    return {
-      tensor: tf.browser.fromPixels(img).expandDims(0) as tf.Tensor4D,
-      type: 'string',
-    };
-  }
 
-  if (isHTMLImageElement(pixels)) {
-    return {
-      tensor: tf.browser.fromPixels(pixels).expandDims(0) as tf.Tensor4D,
-      type: 'HTMLImageElement',
-    };
-  }
+    const tensor = tf.browser.fromPixels(img);
 
-  if (isTensor(pixels)) {
-    if (isFourDimensionalTensor(pixels)) {
+    if (isFourDimensionalTensor(tensor)) {
       return {
-        tensor: pixels,
-        type: 'tensor',
+        tensor,
+        canDispose: true,
       };
     }
 
-    if (isThreeDimensionalTensor(pixels)) {
+    if (isThreeDimensionalTensor(tensor)) {
       return {
-        tensor: pixels.expandDims(0) as tf.Tensor4D,
-        type: 'tensor',
+        tensor: tensor.expandDims(0),
+        canDispose: true,
       };
     }
 
-    throw getInvalidTensorError(pixels);
+    throw getInvalidTensorError(tensor);
   }
 
-  throw getUnknownError(pixels);
+  const tensor = tf.browser.fromPixels(pixels);
+  if (isThreeDimensionalTensor(tensor)) {
+    return {
+      tensor: tensor.expandDims(0),
+      canDispose: true,
+    };
+  }
+
+  return {
+    tensor,
+    canDispose: true,
+  };
 };

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -10,6 +10,8 @@ import { IModelDefinition } from './types';
 jest.mock('./image.generated');
 jest.mock('tensor-as-base64');
 
+const mockImage = image;
+
 describe('getConsistentTensorDimensions', () => {
   interface IOpts {
     width: number;

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -7,10 +7,12 @@ import upscale, {
 import * as tensorAsBase from 'tensor-as-base64';
 import * as image from './image.generated';
 import { IModelDefinition } from './types';
-jest.mock('./image.generated');
+jest.mock('./image.generated', () => ({
+  ...jest.requireActual('./image.generated'),
+}));
 jest.mock('tensor-as-base64');
 
-const mockImage = image;
+const mockedImage = image as jest.Mocked<typeof image>;
 
 describe('getConsistentTensorDimensions', () => {
   interface IOpts {
@@ -1104,9 +1106,9 @@ describe('upscale', () => {
         [4, 4, 4],
       ],
     ]);
-    (image as any).getImageAsPixels = () => ({
+    (mockedImage as any).getImageAsPixels = () => ({
       tensor: img,
-      type: 'tensor',
+      canDispose: true,
     });
     const model = {
       predict: jest.fn(() => tf.ones([1, 2, 2, 3])),
@@ -1127,9 +1129,9 @@ describe('upscale', () => {
         [4, 4, 4],
       ],
     ]);
-    (image as any).getImageAsPixels = () => ({
+    (mockedImage as any).getImageAsPixels = () => ({
       tensor: img,
-      type: 'tensor',
+      canDispose: true,
     });
     const upscaledTensor = tf.ones([1, 2, 2, 3]);
     const model = {

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -3,6 +3,7 @@ import { IUpscaleOptions, IModelDefinition, ProcessFn } from './types';
 import { getImageAsPixels } from './image.generated';
 import tensorAsBase64 from 'tensor-as-base64';
 import { warn } from './utils';
+import { ImageInput } from './image.browser';
 
 const ERROR_UNDEFINED_PADDING =
   'https://thekevinscott.github.io/UpscalerJS/#/?id=padding-is-undefined';
@@ -304,11 +305,11 @@ function getProcessedPixels<T extends tf.Tensor>(
 
 const upscale = async (
   model: tf.LayersModel,
-  image: string | HTMLImageElement | tf.Tensor3D,
+  image: ImageInput,
   modelDefinition: IModelDefinition,
   options: IUpscaleOptions = {},
 ) => {
-  const { tensor: pixels, canDispose } = await getImageAsPixels(image);
+  const { tensor: pixels, canDispose } = await getImageAsPixels(image as any);
 
   const preprocessedPixels = getProcessedPixels<tf.Tensor4D>(
     modelDefinition.preprocess,

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -308,7 +308,7 @@ const upscale = async (
   modelDefinition: IModelDefinition,
   options: IUpscaleOptions = {},
 ) => {
-  const { tensor: pixels, type } = await getImageAsPixels(image);
+  const { tensor: pixels, canDispose } = await getImageAsPixels(image);
 
   const preprocessedPixels = getProcessedPixels<tf.Tensor4D>(
     modelDefinition.preprocess,
@@ -327,9 +327,10 @@ const upscale = async (
     upscaledTensor,
   );
 
-  if (type !== 'tensor') {
-    // if not a tensor, release the memory, since we retrieved it from a string or HTMLImageElement
-    // if it is a tensor, it is user provided and thus should not be disposed of.
+  if (canDispose) {
+    // canDispose indicates we can safely dispose of the tensor.
+    // the only case where we _can't_ safely dispose is when we are using
+    // the original tensor, when it is already in the expected format we need (a rank 4 tensor).
     pixels.dispose();
   }
 


### PR DESCRIPTION
Updates `image.browser.ts` to leverage `tf.browser.fromPixels` if not a tensor or string.

This allows Upscaler to expand it's accepted input types to include:

```pixels: PixelData | ImageData | HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap;```