### PR TITLE
Infer progress type

### DIFF
--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -17,14 +17,17 @@ export type ReturnType = 'src' | 'tensor' | undefined;
 export type UpscaleResponse<O extends ReturnType> = O extends 'src' ? string : tf.Tensor3D;
 export type ProgressResponse<O extends ReturnType = 'src', PO extends ReturnType = undefined> = 
   PO extends 'src' ? 
-    string : 
+    'src' : 
     PO extends 'tensor' ? 
-      tf.Tensor3D : 
-      UpscaleResponse<O>
+      'tensor' :
+      O extends 'tensor' ?
+        'tensor' :
+        'src';
 
-export type MultiArgProgress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = (amount: number, slice: ProgressResponse<O, PO>) => void;
+export type MultiArgProgress<O extends ReturnType = 'src'> = (amount: number, slice: UpscaleResponse<O>) => void;
+// export type MultiArgProgress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = (amount: number, slice: ProgressResponse<O, PO>) => void;
 export type SingleArgProgress = (amount: number) => void;
-export type Progress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = undefined | SingleArgProgress | MultiArgProgress<O, PO>;
+export type Progress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = undefined | SingleArgProgress | MultiArgProgress<ProgressResponse<O, PO>>;
 export interface IUpscaleOptions<P extends Progress<O, PO>, O extends ReturnType = 'src', PO extends ReturnType = undefined>{
   output?: O;
   patchSize?: number;

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -13,20 +13,27 @@ export interface IUpscalerOptions {
   modelDefinition?: IModelDefinition;
 }
 
-export type ProgressSingleArg = (amount: number) => void;
-export type ProgressMultipleArg = (amount: number, slice?: string | tf.Tensor3D) => void;
+export type ReturnType = 'src' | 'tensor' | undefined;
+export type UpscaleResponse<O extends ReturnType> = O extends 'src' ? string : tf.Tensor3D;
+export type ProgressResponse<O extends ReturnType = 'src', PO extends ReturnType = undefined> = 
+  PO extends 'src' ? 
+    string : 
+    PO extends 'tensor' ? 
+      tf.Tensor3D : 
+      UpscaleResponse<O>
 
-export type ReturnType = 'src' | 'tensor';
-export interface IUpscaleOptions<Output extends ReturnType, ProgressOutput extends ReturnType>{
-  output?: Output;
+export type MultiArgProgress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = (amount: number, slice: ProgressResponse<O, PO>) => void;
+export type SingleArgProgress = (amount: number) => void;
+export type Progress<O extends ReturnType = 'src', PO extends ReturnType = undefined> = undefined | SingleArgProgress | MultiArgProgress<O, PO>;
+export interface IUpscaleOptions<P extends Progress<O, PO>, O extends ReturnType = 'src', PO extends ReturnType = undefined>{
+  output?: O;
   patchSize?: number;
   padding?: number;
-  progress?: ProgressSingleArg | ProgressMultipleArg;
-  progressOutput?: ProgressOutput;
+  progress?: P;
+  progressOutput?: PO;
 }
 
 export type ProcessFn<T extends tf.Tensor> = (t: T) => T;
-
 export interface IModelDefinition {
   url: string;
   scale: number;

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -1141,6 +1141,7 @@ describe('predict', () => {
       }),
     } as unknown as tf.LayersModel;
     const progress = jest.fn();
+    
     await predict(model, img, { scale, } as IModelDefinition, {
       patchSize,
       padding: 0,

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -5,6 +5,7 @@ import {
   WarmupSizes,
   IModelDefinition,
   ReturnType,
+  Progress,
 } from './types';
 import loadModel, { getModelDefinitions, } from './loadModel';
 import warmup from './warmup';
@@ -36,9 +37,9 @@ class Upscaler {
     await warmup(this._model, warmupSizes);
   };
 
-  upscale = async<Output extends ReturnType, ProgressOutput extends ReturnType>(
+  upscale = async<P extends Progress<O, PO>, O extends ReturnType = 'src', PO extends ReturnType = undefined>(
     image: GetImageAsTensorInput,
-    options: IUpscaleOptions<Output, ProgressOutput> = {},
+    options: IUpscaleOptions<P, O, PO> = {},
   ) => {
     const { model, modelDefinition, } = await this._model;
     return upscale(model, image, modelDefinition, options);

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -1,5 +1,33 @@
 import * as tf from '@tensorflow/tfjs';
-import { isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from './utils';
+import { isSingleArgProgress, isMultiArgProgress, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from './utils';
+
+describe('isSingleArgProgress', () => {
+  it('returns true for function', () => {
+    expect(isSingleArgProgress(() => {})).toEqual(true);
+  });
+
+  it('returns true for a single arg function', () => {
+    expect(isSingleArgProgress((_1: any) => {})).toEqual(false);
+  });
+
+  it('returns false for a double arg function', () => {
+    expect(isSingleArgProgress((_1: any, _2: any) => {})).toEqual(true);
+  });
+});
+
+describe('isMultiArgProgress', () => {
+  it('returns true for a multi arg function', () => {
+    expect(isMultiArgProgress((_1: any, _2: any) => {})).toEqual(true);
+  });
+
+  it('returns false for a single arg function', () => {
+    expect(isMultiArgProgress((_1: any) => {})).toEqual(false);
+  });
+
+  it('returns false for a zero arg function', () => {
+    expect(isMultiArgProgress(() => {})).toEqual(false);
+  });
+});
 
 describe('isString', () => {
   it('returns true for a string', () => {

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -1,5 +1,5 @@
 import * as tf from '@tensorflow/tfjs';
-import { isSingleArgProgress, isMultiArgProgress, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from './utils';
+import { isSingleArgProgress, isMultiArgTensorProgress, isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from './utils';
 
 describe('isSingleArgProgress', () => {
   it('returns true for function', () => {
@@ -7,25 +7,37 @@ describe('isSingleArgProgress', () => {
   });
 
   it('returns true for a single arg function', () => {
-    expect(isSingleArgProgress((_1: any) => {})).toEqual(false);
+    expect(isSingleArgProgress((_1: any) => {})).toEqual(true);
   });
 
   it('returns false for a double arg function', () => {
-    expect(isSingleArgProgress((_1: any, _2: any) => {})).toEqual(true);
+    expect(isSingleArgProgress((_1: any, _2: any) => {})).toEqual(false);
   });
 });
 
 describe('isMultiArgProgress', () => {
-  it('returns true for a multi arg function', () => {
-    expect(isMultiArgProgress((_1: any, _2: any) => {})).toEqual(true);
-  });
-
   it('returns false for a single arg function', () => {
-    expect(isMultiArgProgress((_1: any) => {})).toEqual(false);
+    expect(isMultiArgTensorProgress((_1: any) => {}, undefined, undefined)).toEqual(false);
   });
 
   it('returns false for a zero arg function', () => {
-    expect(isMultiArgProgress(() => {})).toEqual(false);
+    expect(isMultiArgTensorProgress(() => {}, undefined, undefined,  )).toEqual(false);
+  });
+
+  it('returns false for a multi arg tensor string function', () => {
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'src', 'src')).toEqual(false);
+  });
+
+  it('returns false for a multi arg tensor string function with overloaded outputs', () => {
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'tensor', 'src')).toEqual(false);
+  });
+
+  it('returns true for a multi arg tensor function', () => {
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'tensor', 'tensor')).toEqual(true);
+  });
+
+  it('returns true for a multi arg tensor function with conflicting outputs', () => {
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'src', 'tensor')).toEqual(true);
   });
 });
 

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -1,5 +1,6 @@
 import { tf, } from './dependencies.generated';
 import { ROOT, } from './constants';
+import { Progress, MultiArgProgress, SingleArgProgress } from './types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const isString = (pixels: any): pixels is string => typeof pixels === 'string';
@@ -39,3 +40,7 @@ export const warn = (msg: string | string[]) => {
     console.warn(msg);
   }
 };
+
+export const isProgress = (p: undefined | Progress): p is SingleArgProgress | MultiArgProgress => p !== undefined && typeof p === 'function';
+export const isSingleArgProgress = (progress: Progress): progress is SingleArgProgress => isProgress(progress) && progress.length <= 1;
+export const isMultiArgProgress = (progress: Progress): progress is MultiArgProgress => isProgress(progress) && progress.length > 1;

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -1,6 +1,6 @@
 import { tf, } from './dependencies.generated';
 import { ROOT, } from './constants';
-import { Progress, MultiArgProgress, SingleArgProgress } from './types';
+import { Progress, MultiArgProgress, SingleArgProgress, ReturnType } from './types';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export const isString = (pixels: any): pixels is string => typeof pixels === 'string';
@@ -41,6 +41,14 @@ export const warn = (msg: string | string[]) => {
   }
 };
 
-export const isProgress = (p: undefined | Progress): p is SingleArgProgress | MultiArgProgress => p !== undefined && typeof p === 'function';
-export const isSingleArgProgress = (progress: Progress): progress is SingleArgProgress => isProgress(progress) && progress.length <= 1;
-export const isMultiArgProgress = (progress: Progress): progress is MultiArgProgress => isProgress(progress) && progress.length > 1;
+export function isProgress<O extends ReturnType = 'src', PO extends ReturnType = undefined>(p: undefined | Progress<any, any>): p is Exclude<Progress<O, PO>, undefined> { return p !== undefined && typeof p === 'function'; }
+export function isSingleArgProgress(p: Progress<any, any>): p is SingleArgProgress { return isProgress(p) && p.length <= 1; }
+export const isMultiArgTensorProgress = (p: Progress<any, any>, output: ReturnType, progressOutput: ReturnType): p is MultiArgProgress<'tensor'> => {
+  if (!isProgress(p) || p.length <= 1) {
+    return false;
+  }
+  return progressOutput === undefined && output === 'tensor' || progressOutput === 'tensor';
+}
+// export function isProgress         <P extends Progress<O, PO>, O extends ReturnType = 'src', PO extends ReturnType = undefined>(p: P): p is P { return p !== undefined && typeof p === 'function'; }
+// export function isSingleArgProgress<O extends ReturnType = 'src', PO extends ReturnType = undefined>(p: Progress<O, PO>): p is SingleArgProgress { return isProgress(p) && p.length <= 1; }
+// export function isMultiArgProgress <O extends ReturnType = 'src', PO extends ReturnType = undefined>(p: Progress<O, PO>): p is MultiArgProgress<O, PO> { return isProgress(p) && p.length > 1; }


### PR DESCRIPTION
Update types so that:

- Depending on the specified `output` argument, the response from `upscale` is typed correctly. Previously this was returning a union of `tf.Tensor` and `string`.
- Depending on the number of arguments in the progress callback, the appropriate function is returned
- Depending on the `output` and `progressOutput` arguments, the correct type is returned to the progress callback