### PR TITLE
Revert NPM module installation for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ yarn-error.log
 .yarn
 .pnpm-debug.log
 umd-tmp
+*.tgz

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,4 @@
 packages:
   - 'packages/**'
   - 'models/**'
-  - 'test/lib/**'
   - 'examples/**'

--- a/scripts/package-scripts/utils/packages.ts
+++ b/scripts/package-scripts/utils/packages.ts
@@ -43,7 +43,7 @@ export const getPackageJSONPath = (file: string) => {
   return path.resolve(file, 'package.json');
 }
 
-const writePackageJSON = (file: string, contents: Record<string, string | number | Object | Array<any>>) => {
+export const writePackageJSON = (file: string, contents: Record<string, string | number | Object | Array<any>>) => {
   const stringifiedContents = `${JSON.stringify(contents, null, 2)}\n`;
   fs.writeFileSync(getPackageJSONPath(file), stringifiedContents);
 };

--- a/test/integration/node/model.ts
+++ b/test/integration/node/model.ts
@@ -1,5 +1,5 @@
 import { checkImage } from '../../lib/utils/checkImage';
-import { executeNodeScript } from '../../lib/node/prepare';
+import { executeNodeScript, prepareScriptBundleForNodeCJS } from '../../lib/node/prepare';
 import { LOCAL_UPSCALER_NAME } from '../../lib/node/constants';
 
 const JEST_TIMEOUT = 60 * 1000;
@@ -67,6 +67,9 @@ ${getModelPath}
 `;
 
 describe('Model Loading Integration Tests', () => {
+  beforeAll(async () => {
+    await prepareScriptBundleForNodeCJS();
+  });
 //   it("loads the default model", async () => {
 //     const result = await execute(writeScript(`
 // const getModelPath = () => undefined 

--- a/test/integration/node/platform.ts
+++ b/test/integration/node/platform.ts
@@ -1,5 +1,5 @@
 import { checkImage } from '../../lib/utils/checkImage';
-import { executeNodeScript } from '../../lib/node/prepare';
+import { executeNodeScript, prepareScriptBundleForNodeCJS } from '../../lib/node/prepare';
 import { LOCAL_UPSCALER_NAME } from '../../lib/node/constants';
 
 const JEST_TIMEOUT = 60 * 1000;
@@ -63,6 +63,10 @@ const execute = async (contents: string, logExtra = true) => {
 }
 
 describe('Platform Integration Tests', () => {
+  beforeAll(async () => {
+    await prepareScriptBundleForNodeCJS();
+  });
+
   [
     { platform: 'node', deps: `
 const tf = require('@tensorflow/tfjs-node');

--- a/test/lib/esm-esbuild/prepare.ts
+++ b/test/lib/esm-esbuild/prepare.ts
@@ -1,15 +1,43 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as esbuild from 'esbuild';
-import * as rimraf from 'rimraf';
+import fs from 'fs';
+import path from 'path';
+import esbuild from 'esbuild';
+import rimraf from 'rimraf';
 import { copyFixtures } from '../utils/copyFixtures';
 import { updateTFJSVersion } from '../utils/updateTFJSVersion';
+import callExec from '../utils/callExec';
 
 const ROOT = path.join(__dirname);
 export const DIST = path.join(ROOT, '/dist');
+const NODE_MODULES = path.join(ROOT, '/node_modules');
+const UPSCALER_PATH = path.join(ROOT, '../../../packages/upscalerjs')
+
+const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
+  // Make sure we load the version local to node_modules, _not_ the local version on disk,
+  // so we can ensure the build process is accurate and working correctly
+  rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
+
+  await callExec(`mkdir -p ./node_modules`, {
+    cwd: ROOT,
+  });
+
+  rimraf.sync(path.resolve(UPSCALER_PATH, 'node_modules/.ignored_eslint'));
+  rimraf.sync(path.resolve(UPSCALER_PATH, 'node_modules/.ignored_eslint-config-prettier'));
+  rimraf.sync(path.resolve(UPSCALER_PATH, 'node_modules/.ignored_eslint-plugin-prefer-arrow'));
+  rimraf.sync(path.resolve(UPSCALER_PATH, 'node_modules/.ignored_eslint-plugin-jsdoc'));
+
+  await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}/${localNameForPackage}`, {
+    cwd: UPSCALER_PATH,
+  });
+  
+  const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
+  packageJSON.name = localNameForPackage;
+  fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
+}
 
 export const bundle = async () => {
+  const localNameForPackage = 'upscaler-for-esbuild'
   await updateTFJSVersion(ROOT);
+  await moveUpscalerToLocallyNamedPackage(localNameForPackage);
   rimraf.sync(DIST);
   copyFixtures(DIST, false);
 

--- a/test/lib/esm-webpack/prepare.ts
+++ b/test/lib/esm-webpack/prepare.ts
@@ -13,7 +13,6 @@ export const DIST = path.join(ROOT, '/dist');
 const NODE_MODULES = path.join(ROOT, '/node_modules');
 
 const UPSCALER_PATH = path.join(ROOT, '../../../packages/upscalerjs')
-let compiler = undefined;
 
 const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
   // Make sure we load the version local to node_modules, _not_ the local version on disk,
@@ -43,7 +42,7 @@ export const bundleWebpack = (): Promise<void> => new Promise(async (resolve, re
 
   const entryFiles = path.join(ROOT, 'src/index.js');
 
-  compiler = webpack({
+  const compiler = webpack({
     mode: 'production',
     context: ROOT,
     entry: entryFiles,
@@ -66,8 +65,8 @@ export const bundleWebpack = (): Promise<void> => new Promise(async (resolve, re
   });
 
   compiler.run((err, stats) => {
-    if (err || stats.hasErrors()) {
-      reject(err || stats.toJson('errors-only').errors.map(e => e.message));
+    if (err || stats?.hasErrors()) {
+      reject(err || stats?.toJson('errors-only').errors?.map(e => e.message));
     } else {
       resolve();
     }

--- a/test/lib/node/package.json
+++ b/test/lib/node/package.json
@@ -5,7 +5,6 @@
   "dependencies": {
     "@tensorflow/tfjs-node": "^3.18.0",
     "@tensorflow/tfjs-node-gpu": "^3.18.0",
-    "upscaler-for-node": "workspace:upscaler@*",
     "yargs": "^17.3.1"
   },
   "devDependencies": {

--- a/test/lib/node/prepare.ts
+++ b/test/lib/node/prepare.ts
@@ -8,33 +8,12 @@ import { installNodeModules, installUpscaler } from "../shared/prepare";
 
 const ROOT = path.join(__dirname);
 const NODE_MODULES = path.join(ROOT, '/node_modules');
-const UPSCALER_PATH = path.join(ROOT, '../../../packages/upscalerjs')
-
-// const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
-//   // Make sure we load the version local to node_modules, _not_ the local version on disk,
-//   // so we can ensure the build process is accurate and working correctly
-//   rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
-
-//   await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}`, {
-//     cwd: UPSCALER_PATH,
-//   });
-
-//   await callExec(`mv ${NODE_MODULES}/upscalerjs ${NODE_MODULES}/${localNameForPackage}`, {
-//     cwd: UPSCALER_PATH,
-//   });
-  
-//   const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
-//   packageJSON.name = localNameForPackage;
-//   fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
-// }
 
 export const prepareScriptBundleForNodeCJS = async () => {
   const localNameForPackage = 'upscaler-for-node';
 
   await installNodeModules(ROOT);
-  await installUpscaler(path.resolve(NODE_MODULES, localNameForPackage));
-
-  // moveUpscalerToLocallyNamedPackage(localNameForPackage);
+  await installUpscaler(path.resolve(NODE_MODULES, localNameForPackage), localNameForPackage);
 };
 
 type Stdout = (data: string) => void;

--- a/test/lib/node/prepare.ts
+++ b/test/lib/node/prepare.ts
@@ -4,37 +4,37 @@ import fs from 'fs';
 import path from 'path';
 import crypto from 'crypto';
 import rimraf from 'rimraf';
+import { installNodeModules, installUpscaler } from "../shared/prepare";
 
 const ROOT = path.join(__dirname);
 const NODE_MODULES = path.join(ROOT, '/node_modules');
 const UPSCALER_PATH = path.join(ROOT, '../../../packages/upscalerjs')
 
-const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
-  // Make sure we load the version local to node_modules, _not_ the local version on disk,
-  // so we can ensure the build process is accurate and working correctly
-  rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
+// const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
+//   // Make sure we load the version local to node_modules, _not_ the local version on disk,
+//   // so we can ensure the build process is accurate and working correctly
+//   rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
 
-  await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}`, {
-    cwd: UPSCALER_PATH,
-  });
+//   await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}`, {
+//     cwd: UPSCALER_PATH,
+//   });
 
-  await callExec(`mv ${NODE_MODULES}/upscalerjs ${NODE_MODULES}/${localNameForPackage}`, {
-    cwd: UPSCALER_PATH,
-  });
+//   await callExec(`mv ${NODE_MODULES}/upscalerjs ${NODE_MODULES}/${localNameForPackage}`, {
+//     cwd: UPSCALER_PATH,
+//   });
   
-  const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
-  packageJSON.name = localNameForPackage;
-  fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
-}
+//   const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
+//   packageJSON.name = localNameForPackage;
+//   fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
+// }
 
 export const prepareScriptBundleForNodeCJS = async () => {
   const localNameForPackage = 'upscaler-for-node';
 
-  await callExec('npm install', {
-    cwd: ROOT,
-  });
+  await installNodeModules(ROOT);
+  await installUpscaler(path.resolve(NODE_MODULES, localNameForPackage));
 
-  moveUpscalerToLocallyNamedPackage(localNameForPackage);
+  // moveUpscalerToLocallyNamedPackage(localNameForPackage);
 };
 
 type Stdout = (data: string) => void;

--- a/test/lib/node/prepare.ts
+++ b/test/lib/node/prepare.ts
@@ -27,10 +27,10 @@ const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) =>
   fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
 }
 
-export const prepareScriptBundleForCJS = async () => {
+export const prepareScriptBundleForNodeCJS = async () => {
   const localNameForPackage = 'upscaler-for-node';
 
-  await callExec('yarn', {
+  await callExec('npm install', {
     cwd: ROOT,
   });
 
@@ -54,4 +54,6 @@ export const executeNodeScript = async (contents: string, stdout?: Stdout) => {
   await callExec(`node "${FILENAME}"`, {
     cwd: ROOT
   }, stdout);
+
+  rimraf.sync(TMP);
 };

--- a/test/lib/node/prepare.ts
+++ b/test/lib/node/prepare.ts
@@ -1,10 +1,41 @@
 import callExec from "../utils/callExec";
 import { mkdirp } from "fs-extra";
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import crypto from 'crypto';
+import rimraf from 'rimraf';
 
 const ROOT = path.join(__dirname);
+const NODE_MODULES = path.join(ROOT, '/node_modules');
+const UPSCALER_PATH = path.join(ROOT, '../../../packages/upscalerjs')
+
+const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
+  // Make sure we load the version local to node_modules, _not_ the local version on disk,
+  // so we can ensure the build process is accurate and working correctly
+  rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
+
+  await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}`, {
+    cwd: UPSCALER_PATH,
+  });
+
+  await callExec(`mv ${NODE_MODULES}/upscalerjs ${NODE_MODULES}/${localNameForPackage}`, {
+    cwd: UPSCALER_PATH,
+  });
+  
+  const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
+  packageJSON.name = localNameForPackage;
+  fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
+}
+
+export const prepareScriptBundleForCJS = async () => {
+  const localNameForPackage = 'upscaler-for-node';
+
+  await callExec('yarn', {
+    cwd: ROOT,
+  });
+
+  moveUpscalerToLocallyNamedPackage(localNameForPackage);
+};
 
 type Stdout = (data: string) => void;
 export const executeNodeScriptFromFilePath = async (file: string, stdout?: Stdout) => {

--- a/test/lib/shared/prepare.ts
+++ b/test/lib/shared/prepare.ts
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import rimraf from 'rimraf';
+import callExec from "../utils/callExec";
+
+const ROOT = path.join(__dirname, '../../..');
+const UPSCALER_PATH = path.join(ROOT, 'packages/upscalerjs');
+// const moveUpscalerToLocallyNamedPackage = async (localNameForPackage: string) => {
+//   // Make sure we load the version local to node_modules, _not_ the local version on disk,
+//   // so we can ensure the build process is accurate and working correctly
+//   rimraf.sync(`${NODE_MODULES}/${localNameForPackage}`);
+
+
+//   await callExec(`cp -r ${UPSCALER_PATH} ${NODE_MODULES}`, {
+//     cwd: UPSCALER_PATH,
+//   });
+
+//   await callExec(`mv ${NODE_MODULES}/upscalerjs ${NODE_MODULES}/${localNameForPackage}`, {
+//     cwd: UPSCALER_PATH,
+//   });
+  
+//   const packageJSON = JSON.parse(fs.readFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, 'utf-8'));
+//   packageJSON.name = localNameForPackage;
+//   fs.writeFileSync(`${NODE_MODULES}/${localNameForPackage}/package.json`, JSON.stringify(packageJSON, null, 2));
+// }
+
+export const installNodeModules = async (cwd: string) => {
+  await callExec('npm install', {
+    cwd,
+  });
+}
+
+// dest should be the full path to the upscaler package itself, e.g.:
+// /users/foo/upscalerjs/test/lib/node/node_modules/local-upscaler
+export const installUpscaler = async (dest: string) => {
+  await installLocalPackage(UPSCALER_PATH, dest);
+};
+
+const npmPack = async (cwd: string): Promise<string> => {
+  let outputName = '';
+  await callExec('npm pack', {
+    cwd,
+  }, chunk => {
+    outputName = chunk;
+  });
+
+  if (!outputName.endsWith('.tgz')) {
+    throw new Error(`Unexpected output name: ${outputName}`)
+  }
+
+  return outputName;
+};
+
+const unTar = async (cwd: string, fileName: string) => {
+  await callExec(`tar zxvf ${fileName}`, {
+    cwd,
+  });
+}
+
+export const installLocalPackage = async (src: string, dest: string) => {
+  rimraf.sync(dest);
+  const packedFile = await npmPack(src);
+  const tmp = os.tmpdir();
+  const tmpPackedFile = path.resolve(tmp, packedFile);
+  fs.renameSync(path.resolve(src, packedFile), tmpPackedFile)
+  await unTar(tmp, packedFile);
+  await callExec(`mv package ${dest}`, {
+    cwd: tmp,
+  });
+}

--- a/test/lib/utils/callExec.ts
+++ b/test/lib/utils/callExec.ts
@@ -1,6 +1,6 @@
 const { exec } = require("child_process");
 type StdOut = (chunk: string) => void;
-const callExec = (cmd: string, options: any, stdout?: StdOut | boolean): Promise<void> => new Promise((resolve, reject) => {
+const callExec = (cmd: string, options: any, stdout?: StdOut | boolean, stdErr: boolean = true): Promise<void> => new Promise((resolve, reject) => {
   const spawnedProcess = exec(cmd, options, (error: Error) => {
     if (error) {
       reject(error.message);
@@ -8,7 +8,10 @@ const callExec = (cmd: string, options: any, stdout?: StdOut | boolean): Promise
       resolve();
     }
   });
-  spawnedProcess.stderr.pipe(process.stderr);
+
+  if (stdErr) {
+    spawnedProcess.stderr.pipe(process.stderr);
+  }
 
   if (stdout === false) {
 


### PR DESCRIPTION
For Node tests, updates npm modules to be installed manually (rather than being linked locally by pnpm, which I'm worried will hide implementation problems)