### PR TITLE
Patch sizes in Node crash

### DIFF
--- a/packages/upscalerjs/.eslintrc.js
+++ b/packages/upscalerjs/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
     "@typescript-eslint"
   ],
   "rules": {
-    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/semi": ["error", "always"],
     "comma-dangle": ["error", "always"],
     "curly": ["error", "all"],

--- a/packages/upscalerjs/.eslintrc.js
+++ b/packages/upscalerjs/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     "@typescript-eslint"
   ],
   "rules": {
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/semi": ["error", "always"],
     "comma-dangle": ["error", "always"],
     "curly": ["error", "all"],

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -1368,25 +1368,25 @@ describe('predict', () => {
 
   describe('memory cleanup in predict', () => {
     it('should clear up all memory while running predict without patch size', async () => {
-      const img: tf.Tensor4D = tf.tidy(() => tf.ones([4, 4, 3,]).expandDims(0));
+      const IMG_SIZE = 2;
+      tensor = getTensor(IMG_SIZE, IMG_SIZE).expandDims(0) as tf.Tensor4D;
       const startingTensors = tf.memory().numTensors;
-      const gen = predict(img, {}, modelPackage);
+      const gen = predict(tensor, {}, modelPackage);
       let { value, done } = await gen.next();
       expect(done).toEqual(true);
       expect(Array.isArray(value)).toEqual(false);
-      expect((value as tf.Tensor).dataSync()).toEqual(img.dataSync());
+      tf.tidy(() => checkStartingTensorAgainstUpscaledTensor(tensor, value as tf.Tensor4D));
       (value as tf.Tensor).dispose();
       expect(tf.memory().numTensors).toEqual(startingTensors);
-      img.dispose();
     });
 
     it('should clear up all memory while running predict with patch size', async () => {
       console.warn = jest.fn();
       const IMG_SIZE = 4;
-      const img: tf.Tensor4D = tf.tidy(() => tf.ones([IMG_SIZE, IMG_SIZE, 3,]).expandDims(0));
+      tensor = getTensor(IMG_SIZE, IMG_SIZE).expandDims(0) as tf.Tensor4D;
       const startingTensors = tf.memory().numTensors;
       const patchSize = 2;
-      const gen = predict(img, {
+      const gen = predict(tensor, {
         patchSize,
       }, modelPackage);
 
@@ -1479,7 +1479,6 @@ describe('predict', () => {
       expect(currentExpectationIndex === expectations.length);
       
       expect(tf.memory().numTensors).toEqual(startingTensors);
-      img.dispose();
     });
   });
 });

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -20,6 +20,7 @@ import {
   GET_TENSOR_DIMENSION_ERROR_HEIGHT_IS_UNDEFINED,
   GET_TENSOR_DIMENSION_ERROR_WIDTH_IS_UNDEFINED,
   makeTick,
+  UNDEFINED_TENSORS_ERROR,
 } from './upscale';
 import { tensorAsBase64 as _tensorAsBase64, getImageAsTensor as _getImageAsTensor, } from './image.generated';
 import { wrapGenerator, isTensor as _isTensor, } from './utils';
@@ -69,6 +70,10 @@ describe('concatTensors', () => {
     expect(result.dataSync()).toEqual(expected.dataSync());
     expect(a.isDisposed).toBe(true);
     expect(b.isDisposed).toBe(true);
+  });
+
+  it('throws if given no tensors', () => {
+    expect(concatTensors([undefined, undefined])).toThrowError(UNDEFINED_TENSORS_ERROR);
   });
 });
 

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -20,7 +20,7 @@ import {
   GET_TENSOR_DIMENSION_ERROR_HEIGHT_IS_UNDEFINED,
   GET_TENSOR_DIMENSION_ERROR_WIDTH_IS_UNDEFINED,
   makeTick,
-  UNDEFINED_TENSORS_ERROR,
+  GET_UNDEFINED_TENSORS_ERROR,
 } from './upscale';
 import { tensorAsBase64 as _tensorAsBase64, getImageAsTensor as _getImageAsTensor, } from './image.generated';
 import { wrapGenerator, isTensor as _isTensor, } from './utils';
@@ -73,7 +73,7 @@ describe('concatTensors', () => {
   });
 
   it('throws if given no tensors', () => {
-    expect(concatTensors([undefined, undefined])).toThrowError(UNDEFINED_TENSORS_ERROR);
+    expect(() => concatTensors([undefined, undefined])).toThrowError(GET_UNDEFINED_TENSORS_ERROR());
   });
 });
 

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -1439,7 +1439,7 @@ describe('predict', () => {
         expect(tf.memory().numTensors).toEqual(expectation.count);
         if (expectation.shouldDispose) {
           if (Array.isArray(result.value)) {
-            result.value.forEach(t => t.dispose());
+            result.value.forEach(t => t?.dispose());
           } else if (_isTensor(result.value)) {
             result.value.dispose();
           }

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -279,20 +279,10 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
   const patchSize = originalPatchSize;
 
   if (patchSize) {
-    // const channels = 3;
     const [height, width,] = pixels.shape.slice(1);
     const { rows, columns, } = getRowsAndColumns(pixels, patchSize);
     yield;
-    // const { size: originalSize, } = getTensorDimensions({
-    //   row: 0,
-    //   col: 0,
-    //   patchSize,
-    //   height,
-    //   width,
-    //   padding,
-    // });
     let upscaledTensor: undefined | tf.Tensor4D;
-    yield upscaledTensor;
     const total = rows * columns;
     for (let row = 0; row < rows; row++) {
       let colTensor: undefined | tf.Tensor4D;

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -50,7 +50,7 @@ export const GET_INVALID_SHAPED_TENSOR = (tensor: tf.Tensor): Error => new Error
   )}`,
 );
 
-export const UNDEFINED_TENSORS_ERROR = new Error('No defined tensors were passed to concatTensors');
+export const GET_UNDEFINED_TENSORS_ERROR = () => new Error('No defined tensors were passed to concatTensors');
 
 export const getWidthAndHeight = (tensor: tf.Tensor3D | tf.Tensor4D): [number, number] => {
   if (isFourDimensionalTensor(tensor)) {
@@ -255,7 +255,7 @@ export function concatTensors<T extends tf.Tensor3D | tf.Tensor4D> (tensors: Arr
     }
   }
   if (definedTensors.length === 0) {
-    throw UNDEFINED_TENSORS_ERROR;
+    throw GET_UNDEFINED_TENSORS_ERROR();
   }
   const concatenatedTensor = tf.concat(definedTensors, axis);
   tensors.forEach(tensor => tensor?.dispose());

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -337,12 +337,16 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
       }
 
       upscaledTensor = concatTensors<tf.Tensor4D>([upscaledTensor, colTensor,], 1);
+
+      /* eslint-disable @typescript-eslint/no-non-null-assertion */
       colTensor!.dispose();
       yield [upscaledTensor,];
     }
     // https://github.com/tensorflow/tfjs/issues/1125
     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     const squeezedTensor = upscaledTensor!.squeeze() as tf.Tensor3D;
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
     upscaledTensor!.dispose();
     return squeezedTensor;
   }

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -260,6 +260,7 @@ export function concatTensors<T extends tf.Tensor3D | tf.Tensor4D> (tensors: Arr
   return concatenatedTensor as T;
 }
 
+/* eslint-disable @typescript-eslint/require-await */
 export async function* predict<P extends Progress<O, PO>, O extends ResultFormat = 'src', PO extends ResultFormat = undefined>(
   pixels: tf.Tensor4D,
   { output, progress, patchSize: originalPatchSize, padding, progressOutput, }: UpscaleArgs<P, O, PO>,
@@ -268,8 +269,6 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
     modelDefinition,
   }: ModelPackage
 ): AsyncGenerator<YieldedIntermediaryValue, tf.Tensor3D> {
-  // TODO: Remove this
-  await Promise.resolve();
   const scale = modelDefinition.scale;
 
   if (originalPatchSize && padding === undefined) {

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -50,6 +50,8 @@ export const GET_INVALID_SHAPED_TENSOR = (tensor: tf.Tensor): Error => new Error
   )}`,
 );
 
+export const UNDEFINED_TENSORS_ERROR = new Error('No defined tensors were passed to concatTensors');
+
 export const getWidthAndHeight = (tensor: tf.Tensor3D | tf.Tensor4D): [number, number] => {
   if (isFourDimensionalTensor(tensor)) {
     return [tensor.shape[1], tensor.shape[2],];
@@ -253,7 +255,7 @@ export function concatTensors<T extends tf.Tensor3D | tf.Tensor4D> (tensors: Arr
     }
   }
   if (definedTensors.length === 0) {
-    throw new Error('No defined tensors were passed to concatTensors');
+    throw UNDEFINED_TENSORS_ERROR;
   }
   const concatenatedTensor = tf.concat(definedTensors, axis);
   tensors.forEach(tensor => tensor?.dispose());

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -283,38 +283,19 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
     const [height, width,] = pixels.shape.slice(1);
     const { rows, columns, } = getRowsAndColumns(pixels, patchSize);
     yield;
-    const { size: originalSize, } = getTensorDimensions({
-      row: 0,
-      col: 0,
-      patchSize,
-      height,
-      width,
-      padding,
-    });
-    console.log(originalSize);
-    // const totalWidth = originalSize[1] * scale * columns;
-    // const totalHeight = originalSize[0] * scale;
-    const totalWidth = 64;
-    const totalHeight = 60;
-    console.log('final width', totalWidth);
-    console.log('final height', totalHeight);
+    // const { size: originalSize, } = getTensorDimensions({
+    //   row: 0,
+    //   col: 0,
+    //   patchSize,
+    //   height,
+    //   width,
+    //   padding,
+    // });
     let upscaledTensor: undefined | tf.Tensor4D;
-    //  = tf.zeros([
-    //   1,
-    //   64,
-    //   0,
-    //   channels,
-    // ]);
     yield upscaledTensor;
     const total = rows * columns;
     for (let row = 0; row < rows; row++) {
       let colTensor: undefined | tf.Tensor4D;
-      //  = tf.zeros([
-      //   1,
-      //   0,
-      //   16,
-      //   channels,
-      // ]);
       yield [colTensor, upscaledTensor,];
       for (let col = 0; col < columns; col++) {
         const { origin, size, sliceOrigin, sliceSize, } = getTensorDimensions({
@@ -361,13 +342,11 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
         }
         yield [upscaledTensor, colTensor, slicedPrediction,];
 
-        console.log('concat the col tensor');
         colTensor = concatTensors<tf.Tensor4D>([colTensor, slicedPrediction,], 2);
         slicedPrediction.dispose();
         yield [upscaledTensor, colTensor,];
       }
 
-      console.log('concat the final tensor');
       upscaledTensor = concatTensors<tf.Tensor4D>([upscaledTensor, colTensor,], 1);
       colTensor!.dispose();
       yield [upscaledTensor,];

--- a/test/integration/node/image.ts
+++ b/test/integration/node/image.ts
@@ -184,16 +184,16 @@ describe('Node Image Loading Integration Tests', () => {
     });
   });
 
-  // describe('Patch sizes', () => {
-  //   it.only("upscales an imported local image path with patch sizes", async () => {
-  //     const result = await testRunner.test({
-  //       globals: {
-  //         image: JSON.stringify(IMAGE_FIXTURE_PATH),
-  //         patchSize: 4,
-  //         padding: 2,
-  //       },
-  //     });
-  //     checkImage(`data:image/png;base64,${result}`, EXPECTED_UPSCALED_IMAGE, DIFF_IMAGE_OUTPUT);
-  //   });
-  // });
+  describe('Patch sizes', () => {
+    it("upscales an imported local image path with patch sizes", async () => {
+      const result = await testRunner.test({
+        globals: {
+          image: JSON.stringify(IMAGE_FIXTURE_PATH),
+          patchSize: 4,
+          padding: 2,
+        },
+      });
+      checkImage(`data:image/png;base64,${result}`, EXPECTED_UPSCALED_IMAGE_15, DIFF_IMAGE_OUTPUT);
+    });
+  });
 });

--- a/test/integration/utils/NodeTestRunner.ts
+++ b/test/integration/utils/NodeTestRunner.ts
@@ -77,7 +77,6 @@ export class NodeTestRunner {
         testName: expect.getState().currentTestName,
       });
     } catch(err: any) {
-      console.log(err);
       const message = err.message;
       const pertinentLine = message.split('Error: ').pop().split('\n')[0].trim();
       throw new Error(pertinentLine);


### PR DESCRIPTION
Fix for #356 

The reason for the crash is that there is a discrepancy between how tensors are concatenated between Node and Browser in TFJS.

This PR refactors the code to avoid concatenation until such time as the tensor's dimensions are known (effectively, after the first loop).