### PR TITLE
Rename src to base64

### DIFF
--- a/packages/upscalerjs/src/index.ts
+++ b/packages/upscalerjs/src/index.ts
@@ -1,4 +1,4 @@
 export { default, } from './upscaler';
 export { AbortError, getRowsAndColumns, getTensorDimensions, } from './upscale';
 export type { ModelDefinition, } from '@upscalerjs/core';
-export type { SingleArgProgress, MultiArgProgress, Progress, } from './types';
+export type { BASE64, TENSOR, SingleArgProgress, MultiArgProgress, Progress, } from './types';

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -12,8 +12,8 @@ export interface UpscalerOptions {
   warmupSizes?: WarmupSizes[];
 }
 
-type BASE64 = 'base64';
-type TENSOR = 'tensor';
+export type BASE64 = 'base64';
+export type TENSOR = 'tensor';
 export type ResultFormat = BASE64 | TENSOR | undefined;
 export type UpscaleResponse<O extends ResultFormat> = O extends BASE64 ? string : tf.Tensor3D;
 export type ProgressResponse<O extends ResultFormat = BASE64, PO extends ResultFormat = undefined> = 

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -12,21 +12,23 @@ export interface UpscalerOptions {
   warmupSizes?: WarmupSizes[];
 }
 
-export type ResultFormat = 'src' | 'tensor' | undefined;
-export type UpscaleResponse<O extends ResultFormat> = O extends 'src' ? string : tf.Tensor3D;
-export type ProgressResponse<O extends ResultFormat = 'src', PO extends ResultFormat = undefined> = 
-  PO extends 'src' ? 
-    'src' : 
-    PO extends 'tensor' ? 
-      'tensor' :
-      O extends 'tensor' ?
-        'tensor' :
-        'src';
+type BASE64 = 'base64';
+type TENSOR = 'tensor';
+export type ResultFormat = BASE64 | TENSOR | undefined;
+export type UpscaleResponse<O extends ResultFormat> = O extends BASE64 ? string : tf.Tensor3D;
+export type ProgressResponse<O extends ResultFormat = BASE64, PO extends ResultFormat = undefined> = 
+  PO extends BASE64 ? 
+    BASE64 : 
+    PO extends TENSOR ? 
+      TENSOR :
+      O extends TENSOR ?
+        TENSOR :
+        BASE64;
 
-export type MultiArgProgress<O extends ResultFormat = 'src'> = (amount: number, slice: UpscaleResponse<O>) => void;
+export type MultiArgProgress<O extends ResultFormat = BASE64> = (amount: number, slice: UpscaleResponse<O>) => void;
 export type SingleArgProgress = (amount: number) => void;
-export type Progress<O extends ResultFormat = 'src', PO extends ResultFormat = undefined> = undefined | SingleArgProgress | MultiArgProgress<ProgressResponse<O, PO>>;
-export interface UpscaleArgs<P extends Progress<O, PO>, O extends ResultFormat = 'src', PO extends ResultFormat = undefined>{
+export type Progress<O extends ResultFormat = BASE64, PO extends ResultFormat = undefined> = undefined | SingleArgProgress | MultiArgProgress<ProgressResponse<O, PO>>;
+export interface UpscaleArgs<P extends Progress<O, PO>, O extends ResultFormat = BASE64, PO extends ResultFormat = undefined>{
   output?: O;
   patchSize?: number;
   padding?: number;

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -25,7 +25,7 @@ import {
 import { tensorAsBase64 as _tensorAsBase64, getImageAsTensor as _getImageAsTensor, } from './image.generated';
 import { wrapGenerator, isTensor as _isTensor, } from './utils';
 import { ModelDefinition } from "@upscalerjs/core";
-import { ModelPackage, Progress, } from './types';
+import { BASE64, ModelPackage, Progress, TENSOR, } from './types';
 import { mockFn } from '../../../test/lib/shared/mockers';
 
 jest.mock('./image.generated', () => {
@@ -1325,13 +1325,13 @@ describe('predict', () => {
       } else {
         throw new Error(`Unexpected rate: ${rate}`);
       }
-    }) as Progress<'src', 'tensor'>
+    }) as Progress<BASE64, TENSOR>
     await wrapGenerator(
       predict(tensor, {
         patchSize,
         padding: 0,
         progress,
-        output: 'src',
+        output: 'base64',
         progressOutput: 'tensor',
       }, modelPackage)
     );
@@ -1489,7 +1489,7 @@ describe('predict', () => {
 });
 
 describe('upscale', () => {
-  it('should return a base64 src by default', async () => {
+  it('should return a base64 string by default', async () => {
     const img: tf.Tensor3D = tf.tensor([
       [
         [1, 1, 1,],

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -322,7 +322,7 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
           const index = row * columns + col + 1;
           const percent = index / total;
           if (progress.length <= 1) {
-            (<SingleArgProgress>progress)(percent);
+            progress(percent);
           } else {
             const squeezedTensor: tf.Tensor3D = slicedPrediction.squeeze();
             if (isMultiArgTensorProgress(progress, output, progressOutput)) {

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -6,7 +6,6 @@ import type {
   UpscaleResponse, 
   Progress, 
   MultiArgProgress,
-  SingleArgProgress,
   ModelPackage,
   BASE64,
   TENSOR,

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -6,6 +6,7 @@ import type {
   UpscaleResponse, 
   Progress, 
   MultiArgProgress,
+  SingleArgProgress,
   ModelPackage,
   BASE64,
   TENSOR,
@@ -321,7 +322,7 @@ export async function* predict<P extends Progress<O, PO>, O extends ResultFormat
           const index = row * columns + col + 1;
           const percent = index / total;
           if (progress.length <= 1) {
-            progress(percent);
+            (<SingleArgProgress>progress)(percent);
           } else {
             const squeezedTensor: tf.Tensor3D = slicedPrediction.squeeze();
             if (isMultiArgTensorProgress(progress, output, progressOutput)) {

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -7,6 +7,7 @@ import type {
   Progress,
   UpscaleResponse,
   ModelPackage,
+  BASE64,
 } from './types';
 import { loadModel, } from './loadModel.generated';
 import { warmup, } from './warmup';
@@ -43,7 +44,7 @@ export class Upscaler {
     await warmup(this._model, warmupSizes);
   };
 
-  upscale = async<P extends Progress<O, PO>, O extends ResultFormat = 'src', PO extends ResultFormat = undefined>(
+  upscale = async<P extends Progress<O, PO>, O extends ResultFormat = BASE64, PO extends ResultFormat = undefined>(
     image: GetImageAsTensorInput,
     options: UpscaleArgs<P, O, PO> = {},
   ): Promise<UpscaleResponse<O>> => {

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -231,11 +231,11 @@ describe('isMultiArgProgress', () => {
   });
 
   it('returns false for a multi arg tensor string function', () => {
-    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'src', 'src')).toEqual(false);
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'base64', 'base64')).toEqual(false);
   });
 
   it('returns false for a multi arg tensor string function with overloaded outputs', () => {
-    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'tensor', 'src')).toEqual(false);
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'tensor', 'base64')).toEqual(false);
   });
 
   it('returns true for a multi arg tensor function', () => {
@@ -243,7 +243,7 @@ describe('isMultiArgProgress', () => {
   });
 
   it('returns true for a multi arg tensor function with conflicting outputs', () => {
-    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'src', 'tensor')).toEqual(true);
+    expect(isMultiArgTensorProgress((_1: any, _2: any) => {}, 'base64', 'tensor')).toEqual(true);
   });
 });
 

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -1,5 +1,5 @@
 import { tf, } from './dependencies.generated';
-import type { Progress, MultiArgProgress, SingleArgProgress, ResultFormat, } from './types';
+import type { BASE64, TENSOR, Progress, MultiArgProgress, SingleArgProgress, ResultFormat, } from './types';
 import type { ModelDefinitionFn, ModelDefinition, ModelDefinitionObjectOrFn, } from '@upscalerjs/core';
 
 export const isString = (pixels: unknown): pixels is string => typeof pixels === 'string';
@@ -56,9 +56,9 @@ export const warn = (msg: string | string[]): void => {
   console.warn(Array.isArray(msg) ? msg.join('\n') : msg);// skipcq: JS-0002
 };
 
-export function isProgress<O extends ResultFormat = 'src', PO extends ResultFormat = undefined>(p: undefined | Progress<ResultFormat, ResultFormat>): p is Exclude<Progress<O, PO>, undefined> { return p !== undefined && typeof p === 'function'; }
+export function isProgress<O extends ResultFormat = BASE64, PO extends ResultFormat = undefined>(p: undefined | Progress<ResultFormat, ResultFormat>): p is Exclude<Progress<O, PO>, undefined> { return p !== undefined && typeof p === 'function'; }
 export function isSingleArgProgress(p: Progress<ResultFormat, ResultFormat>): p is SingleArgProgress { return isProgress(p) && p.length <= 1; }
-export const isMultiArgTensorProgress = (p: Progress<ResultFormat, ResultFormat>, output: ResultFormat, progressOutput: ResultFormat): p is MultiArgProgress<'tensor'> => {
+export const isMultiArgTensorProgress = (p: Progress<ResultFormat, ResultFormat>, output: ResultFormat, progressOutput: ResultFormat): p is MultiArgProgress<TENSOR> => {
   if (!isProgress(p) || p.length <= 1) {
     return false;
   }

--- a/test/integration/browser/upscale.ts
+++ b/test/integration/browser/upscale.ts
@@ -4,7 +4,7 @@
 import { checkImage } from '../../lib/utils/checkImage';
 import { bundle, DIST, mockCDN as esbuildMockCDN } from '../../lib/esm-esbuild/prepare';
 import * as tf from '@tensorflow/tfjs';
-import Upscaler, { Progress } from 'upscaler';
+import Upscaler, { BASE64, Progress } from 'upscaler';
 import { BrowserTestRunner } from '../utils/BrowserTestRunner';
 
 const TRACK_TIME = false;
@@ -215,7 +215,7 @@ describe('Upscale Integration Tests', () => {
         upscaler.upscale(window['flower'], {
           patchSize: 8,
           padding: 2,
-          output: 'src',
+          output: 'base64',
           progress: (rate: number) => {
             progressRates.push(rate);
           },
@@ -226,7 +226,7 @@ describe('Upscale Integration Tests', () => {
       expect(progressRates).toEqual([.25, .5, .75, 1]);
     });
 
-    it("calls back to progress with a src", async () => {
+    it("calls back to progress with a base64", async () => {
       const [rate, slice] = await page().evaluate((): Promise<[number, string]> => new Promise(resolve => {
         const upscaler = new window['Upscaler']({
           model: {
@@ -234,13 +234,13 @@ describe('Upscale Integration Tests', () => {
             scale: 4,
           },
         });
-        const progress: Progress<'src'> = (rate, slice) => {
+        const progress: Progress<BASE64> = (rate, slice) => {
           resolve([rate, slice]);
         };
         upscaler.upscale(window['flower'], {
           patchSize: 12,
           padding: 2,
-          output: 'src',
+          output: 'base64',
           progress,
         });
       }));

--- a/test/integration/browser/upscale.ts
+++ b/test/integration/browser/upscale.ts
@@ -71,7 +71,7 @@ describe('Upscale Integration Tests', () => {
         upscaler.upscale(window['flower'], {
           patchSize: 4,
           padding: 2,
-          output: 'src',
+          output: 'base64',
           signal: abortController.signal,
           progress: (rate: number) => {
             const curTime = new Date().getTime();
@@ -125,7 +125,7 @@ describe('Upscale Integration Tests', () => {
         const options: any = {
           patchSize: 4,
           padding: 2,
-          output: 'src',
+          output: 'base64',
           progress: (rate: number) => {
             const curTime = new Date().getTime();
             window['durations'].push(curTime - startTime);
@@ -179,7 +179,7 @@ describe('Upscale Integration Tests', () => {
         const options: any = {
           patchSize: 4,
           padding: 2,
-          output: 'src',
+          output: 'base64',
           progress: (rate: number) => {
             if (rate >= .5) {
               window['upscaler'].abort();

--- a/test/misc/memory/test.browser.ts
+++ b/test/misc/memory/test.browser.ts
@@ -565,7 +565,7 @@ describe('Memory Leaks', () => {
           },
         });
         await upscaler.upscale(window['flower'], {
-          output: 'src',
+          output: 'base64',
           patchSize: 14,
           padding: 2,
           progress: (_, slice) => {
@@ -598,7 +598,7 @@ describe('Memory Leaks', () => {
           },
         });
         await upscaler.upscale(window['flower'], {
-          output: 'src',
+          output: 'base64',
           progressOutput: 'tensor',
           patchSize: 14,
           padding: 2,
@@ -639,7 +639,7 @@ describe('Memory Leaks', () => {
           },
         });
         upscaler.upscale(window['flower'], {
-          output: 'src',
+          output: 'base64',
           signal: abortController.signal,
         }).catch(() => {
           upscaler.dispose().then(resolve);
@@ -668,7 +668,7 @@ describe('Memory Leaks', () => {
         });
         try {
           await upscaler.upscale(window['flower'], {
-            output: 'src',
+            output: 'base64',
             signal: abortController.signal,
             patchSize: 14,
             padding: 2,


### PR DESCRIPTION
Renames the `src` value to `base64` to better match its meaning.