### PR TITLE
Provide a deprecated src option that also prints a deprecation warning

### DIFF
--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -48,8 +48,8 @@ export interface ModelPackage {
 
 // TODO: Remove this in favor of UpscaleArgs. This is to deprecate the 'src' option for output.
 export interface TempUpscaleArgs<P extends Progress<O, PO>, O extends ResultFormat = 'base64', PO extends ResultFormat = undefined> {
-  output?: 'base64' | 'tensor' | 'src';
-  progressOutput?: 'base64' | 'tensor' | 'src';
+  output?: O | 'src';
+  progressOutput?: PO | 'src';
   patchSize?: number;
   padding?: number;
   progress?: P;

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -45,3 +45,13 @@ export interface ModelPackage {
   model: tf.LayersModel;
   modelDefinition: ModelDefinition;
 }
+
+// TODO: Remove this in favor of UpscaleArgs. This is to deprecate the 'src' option for output.
+export interface TempUpscaleArgs<P extends Progress<O, PO>, O extends ResultFormat = 'base64', PO extends ResultFormat = undefined> {
+  output?: 'base64' | 'tensor' | 'src';
+  progressOutput?: 'base64' | 'tensor' | 'src';
+  patchSize?: number;
+  padding?: number;
+  progress?: P;
+  signal?: AbortSignal;
+}

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -8,6 +8,7 @@ import type {
   UpscaleResponse,
   ModelPackage,
   BASE64,
+  UpscaleArgs,
 } from './types';
 import { loadModel, } from './loadModel.generated';
 import { warmup, } from './warmup';
@@ -49,7 +50,8 @@ export class Upscaler {
     options: TempUpscaleArgs<P, O, PO> = {},
   ): Promise<UpscaleResponse<O>> => {
     const { model, modelDefinition, } = await this._model;
-    return cancellableUpscale(image, parseUpscaleOptions<P, O, PO>(options), {
+    const parsedOptions: UpscaleArgs<P, O, PO> = parseUpscaleOptions<P, O, PO>(options);
+    return cancellableUpscale(image, parsedOptions, {
       model,
       modelDefinition,
       signal: this.abortController.signal,

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -1,7 +1,7 @@
 import { ESRGANSlim, } from './dependencies.generated';
 import type {
   UpscalerOptions,
-  UpscaleArgs,
+  TempUpscaleArgs,
   WarmupSizes,
   ResultFormat,
   Progress,
@@ -14,7 +14,7 @@ import { warmup, } from './warmup';
 import { cancellableUpscale, } from './upscale';
 import type { GetImageAsTensorInput, } from './image.generated';
 import type { ModelDefinitionObjectOrFn, } from '@upscalerjs/core';
-import { getModel, } from './utils';
+import { getModel, parseUpscaleOptions, } from './utils';
 
 // TODO: Why do we need to explicitly cast this to ModelDefinition?
 // This is an ESLint issue, Typescript picks this up correctly
@@ -46,10 +46,10 @@ export class Upscaler {
 
   upscale = async<P extends Progress<O, PO>, O extends ResultFormat = BASE64, PO extends ResultFormat = undefined>(
     image: GetImageAsTensorInput,
-    options: UpscaleArgs<P, O, PO> = {},
+    options: TempUpscaleArgs<P, O, PO> = {},
   ): Promise<UpscaleResponse<O>> => {
     const { model, modelDefinition, } = await this._model;
-    return cancellableUpscale(image, options, {
+    return cancellableUpscale(image, parseUpscaleOptions<P, O, PO>(options), {
       model,
       modelDefinition,
       signal: this.abortController.signal,

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -103,18 +103,18 @@ export const getModel = (modelDefinition: ModelDefinitionObjectOrFn): ModelDefin
 
 export const hasValidChannels = (tensor: tf.Tensor): boolean => tensor.shape.slice(-1)[0] === 3;
 
-export function parseUpscaleOptions<P extends Progress<O, PO>, O extends ResultFormat = 'base64', PO extends ResultFormat = undefined> (opts: TempUpscaleArgs<P, O, PO>): UpscaleArgs<P, O, PO> {
-  return {
-    ...opts,
-    output: parseUpscaleOutput('output', opts.output) as O,
-    progressOutput: parseUpscaleOutput('progressOutput', opts.progressOutput) as PO,
-  };
-}
-
 export function parseUpscaleOutput(key: string, option?: 'base64' | 'src' | 'tensor'): undefined | 'base64' | 'tensor' {
   if (option === 'src') {
     console.warn(`You have provided "src" as an option to ${key}. You should switch this to "base64". "src" is deprecated and will be removed in a future version.`);
     return 'base64';
   }
   return option;
+}
+
+export function parseUpscaleOptions<P extends Progress<O, PO>, O extends ResultFormat = 'base64', PO extends ResultFormat = undefined> (opts: TempUpscaleArgs<P, O, PO>): UpscaleArgs<P, O, PO> {
+  return {
+    ...opts,
+    output: parseUpscaleOutput('output', opts.output) as O,
+    progressOutput: parseUpscaleOutput('progressOutput', opts.progressOutput) as PO,
+  };
 }

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -1,5 +1,5 @@
 import { tf, } from './dependencies.generated';
-import type { BASE64, TENSOR, Progress, MultiArgProgress, SingleArgProgress, ResultFormat, } from './types';
+import type { BASE64, TENSOR, Progress, MultiArgProgress, SingleArgProgress, ResultFormat, TempUpscaleArgs, UpscaleArgs, } from './types';
 import type { ModelDefinitionFn, ModelDefinition, ModelDefinitionObjectOrFn, } from '@upscalerjs/core';
 
 export const isString = (pixels: unknown): pixels is string => typeof pixels === 'string';
@@ -102,3 +102,19 @@ export const getModel = (modelDefinition: ModelDefinitionObjectOrFn): ModelDefin
 };
 
 export const hasValidChannels = (tensor: tf.Tensor): boolean => tensor.shape.slice(-1)[0] === 3;
+
+export function parseUpscaleOptions<P extends Progress<O, PO>, O extends ResultFormat = 'base64', PO extends ResultFormat = undefined> (opts: TempUpscaleArgs<P, O, PO>): UpscaleArgs<P, O, PO> {
+  return {
+    ...opts,
+    output: parseUpscaleOutput('output', opts.output) as O,
+    progressOutput: parseUpscaleOutput('progressOutput', opts.progressOutput) as PO,
+  };
+}
+
+export function parseUpscaleOutput(key: string, option?: 'base64' | 'src' | 'tensor'): undefined | 'base64' | 'tensor' {
+  if (option === 'src') {
+    console.warn(`You have provided "src" as an option to ${key}. You should switch this to "base64". "src" is deprecated and will be removed in a future version.`);
+    return 'base64';
+  }
+  return option;
+}

--- a/test/integration/browser/model.ts
+++ b/test/integration/browser/model.ts
@@ -115,13 +115,13 @@ describe('Model Loading Integration Tests', () => {
   it('does not clip a model that returns out of bound numbers when returning a tensor', async () => {
     const startingPixels = [-100,-100,-100,0,0,0,255,255,255,1000,1000,1000];
     const predictedPixels: number[] = await page().evaluate((startingPixels) => {
-      const upscaler = new window['Upscaler']({
+      const upscaler: Upscaler = new window['Upscaler']({
         model: window['pixel-upsampler']['2x'],
       });
       const tensor = tf.tensor(startingPixels).reshape([2,2,3]) as Tensor3D;
-      return upscaler.upscale(tensor, {
+      return upscaler.upscale<any, 'tensor'>(tensor, {
         output: 'tensor',
-      }).then((output: Tensor) => {
+      }).then((output) => {
         return Array.from(output.dataSync());
       });
     }, startingPixels);


### PR DESCRIPTION
`src` is deprecated as an option for output in favor of `base64`.

We'll still support `src` for now but print a warning, and remove it in a future version.