### PR TITLE
Add fixes for canceling in safari

### DIFF
--- a/docs/src/components/demo/hooks/useImages.ts
+++ b/docs/src/components/demo/hooks/useImages.ts
@@ -30,12 +30,12 @@ export const useImages = () => {
     patchSize,
     choosePatchSize,
     benchmarks, 
-    hasBeenBenchmarked, cancelUpscale: _cancelUpscale, progress, upscaledSrc } = useUpscaler(img);
+    hasBeenBenchmarked, cancelUpscale: cancelUpscale, progress, upscaledSrc } = useUpscaler(img);
 
   const setUploadedImage = useCallback(async (uploadedImage?: UploadedImage) => {
     if (uploadedImage?.src !== _originalImage?.src) {
       reset();
-      _cancelUpscale();
+      cancelUpscale();
       if (uploadedImage) {
         _setHasBeenRescaled(false);
         const { src, filename } = uploadedImage;
@@ -55,15 +55,11 @@ export const useImages = () => {
         }
       }
     }
-  }, [_originalImage, _cancelUpscale, _setOriginalImage, _setChoice, _setHasBeenRescaled, _setDownscaledImage, reset]);
+  }, [_originalImage, cancelUpscale, _setOriginalImage, _setChoice, _setHasBeenRescaled, _setDownscaledImage, reset]);
 
   const chooseWhichImageToUse = useCallback((chosenChoice) => {
     _setChoice(chosenChoice);
   }, [_setChoice]);
-
-  const cancelUpscale = useCallback(() => {
-    _cancelUpscale();
-  }, [reset, _cancelUpscale])
 
   return {
     cancelUpscale,

--- a/docs/src/components/demo/hooks/useUpscaler.ts
+++ b/docs/src/components/demo/hooks/useUpscaler.ts
@@ -26,6 +26,8 @@ const PATCH_SIZES = [
   1024,
 ];
 
+let imageId = 0;
+
 export const useUpscaler = (img?: HTMLImageElement) => {
   const [upscaling, setUpscaling] = useState(false);
   const [progress, setProgress] = useState<number>();
@@ -40,7 +42,7 @@ export const useUpscaler = (img?: HTMLImageElement) => {
     upscaledSrc.current = newSrc;
   }, []);
 
-  const [patchSize, setPatchSize] = useState<number>();
+  const [patchSize, setPatchSize] = useState<number>(16);
 
   const worker = useRef<Worker>();
 
@@ -104,27 +106,36 @@ export const useUpscaler = (img?: HTMLImageElement) => {
         setHasBeenBenchmarked(true);
       }
       if (type === SenderWorkerState.PROGRESS) {
-        const {
-          id,
-          rate,
-          row,
-          col,
-          slice,
-          shape,
-        } = data;
-        if (id === img.src) {
-          setProgress(rate);
-          const tensor = tf.tensor3d(slice, shape);
-          const dataURL = await tensorAsBase64(tensor);
-          tensor.dispose();
-          setUpscaledSrc(await drawImage(dataURL, patchSize * SCALE, col, row));
-          if (rate === 1) {
-            setUpscaling(false);
+        if (upscaling) {
+          const {
+            id,
+            rate,
+            row,
+            col,
+            slice,
+            shape,
+            imageId: _imageId,
+          } = data;
+          if (imageId === _imageId) {
+            if (id === img.src) {
+              setProgress(rate);
+              const tensor = tf.tensor3d(slice, shape);
+              const dataURL = await tensorAsBase64(tensor);
+              tensor.dispose();
+              setUpscaledSrc(await drawImage(dataURL, patchSize * SCALE, col, row));
+              if (rate === 1) {
+                setUpscaling(false);
+              }
+            }
+          } else {
+            console.warn('Received progress event, but the image id did not match the active image id')
           }
+        } else {
+          console.warn('Received progress event, but we are not supposed to be upscaling.');
         }
       }
     }
-  }, [setBenchmarks, img, patchSize, setProgress, setUpscaledSrc,]);
+  }, [upscaling, setBenchmarks, img, patchSize, setProgress, setUpscaledSrc,]);
 
   const upscale = useCallback(async (img: HTMLImageElement) => {
     setUpscaledSrc(createCanvas(img));
@@ -136,6 +147,7 @@ export const useUpscaler = (img?: HTMLImageElement) => {
       worker.current.postMessage({
         type: ReceiverWorkerState.UPSCALE,
         data: {
+          imageId,
           pixels: src.dataSync(),
           shape: src.shape,
           patchSize,
@@ -150,14 +162,12 @@ export const useUpscaler = (img?: HTMLImageElement) => {
   }, [patchSize, createCanvas, setUpscaling, setProgress]);
 
   const cancelUpscale = useCallback(() => {
-    try {
-      worker.current.postMessage({
-        type: ReceiverWorkerState.ABORT,
-      });
-    } catch(err) {}
+    worker.current.postMessage({
+      type: ReceiverWorkerState.ABORT,
+    });
     setUpscaling(false);
     setProgress(undefined);
-  }, [setUpscaling]);
+  }, [setUpscaling, worker]);
 
   useEffect(() => {
     if (img) {

--- a/docs/src/components/demo/hooks/useUpscaler.ts
+++ b/docs/src/components/demo/hooks/useUpscaler.ts
@@ -147,7 +147,7 @@ export const useUpscaler = (img?: HTMLImageElement) => {
       worker.current.postMessage({
         type: ReceiverWorkerState.UPSCALE,
         data: {
-          imageId,
+          imageId: imageId++,
           pixels: src.dataSync(),
           shape: src.shape,
           patchSize,

--- a/docs/src/components/demo/hooks/worker.ts
+++ b/docs/src/components/demo/hooks/worker.ts
@@ -87,6 +87,7 @@ onmessage = async ({ data: { type, data } }) => {
       shape,
       patchSize,
       padding,
+      imageId,
     } = data;
     const input = tf.tensor3d(pixels, shape);
     try {
@@ -99,6 +100,7 @@ onmessage = async ({ data: { type, data } }) => {
           postMessage({
             type: SenderWorkerState.PROGRESS,
             data: {
+              imageId,
               id,
               rate,
               row,


### PR DESCRIPTION
There's a bug in the demo, present in Safari (not on Chrome) whereby executing a cancel request fails to actually cancel the request.

I _think_ this is due to a bug in the web worker implementation. It appears that certain `postMessage` commands in Safari are just dropped, possibly because the upscaling request is hogging the thread. Chrome works fine.

I added some guard rails to avoid the cancel failure to propagate to the UI, but I don't know how to fix the core underlying issue.