### PR TITLE
Update Stackblitz links

### DIFF
--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -2,4 +2,4 @@
 
 Shows a basic use case of UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/basic).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/basic?file=index.js&title=UpscalerJS: Basic Example).

--- a/examples/cancel/README.md
+++ b/examples/cancel/README.md
@@ -2,4 +2,4 @@
 
 Demonstrates how to cancel an inflight `upscale` request.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/cancel).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/cancel?file=index.js&title=UpscalerJS: Cancel Example).

--- a/examples/patch-sizes/README.md
+++ b/examples/patch-sizes/README.md
@@ -2,4 +2,4 @@
 
 Demos the use of patch sizes with UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/patch-sizes).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/patch-sizes?file=index.js&title=UpscalerJS: Patch Sizes Example).

--- a/examples/progress/README.md
+++ b/examples/progress/README.md
@@ -2,4 +2,4 @@
 
 Shows how to measure progress with UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/progress).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/progress?file=index.js&title=UpscalerJS: Progress Example).

--- a/examples/react-demo/README.md
+++ b/examples/react-demo/README.md
@@ -2,4 +2,4 @@
 
 Shows integration with React and UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/react-demo).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/react-demo?file=index.js&title=UpscalerJS: React Demo Example).

--- a/examples/tensor/README.md
+++ b/examples/tensor/README.md
@@ -1,5 +1,5 @@
-# Tensor Input / Output Example
+# Tensor Example
 
 Shows how to use UpscalerJS with a tensor as input and a tensor as output.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/tensor).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/tensor?file=index.js&title=UpscalerJS: Tensor Example).

--- a/examples/upload/README.md
+++ b/examples/upload/README.md
@@ -2,4 +2,4 @@
 
 Shows an uploading use case of UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/upload).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/upload?file=index.js&title=UpscalerJS: Upload Example).

--- a/examples/warmup/README.md
+++ b/examples/warmup/README.md
@@ -4,4 +4,4 @@ Shows a warmup use case of UpscalerJS.
 
 On first inference pass, the model will perform slower than on subsequent runs. You can avoid this by "warming up" the model, or passing through some dummy data at startup time.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/warmup).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/warmup?file=index.js&title=UpscalerJS: Warmup Example).

--- a/examples/webcam/README.md
+++ b/examples/webcam/README.md
@@ -2,4 +2,4 @@
 
 Shows a webcam use case of UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/webcam).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/webcam?file=index.js&title=UpscalerJS: Webcam Example).

--- a/examples/webworker/README.md
+++ b/examples/webworker/README.md
@@ -2,4 +2,4 @@
 
 Shows a webworker use case of UpscalerJS.
 
-[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/webworker).
+[Open in Stackblitz](https://stackblitz.com/github/thekevinscott/upscalerjs/tree/main/examples/webworker?file=index.js&title=UpscalerJS: Webworker Example).


### PR DESCRIPTION
Update Stackblitz links to default to index.js and set a title for each example