### PR TITLE
Make awaiting a next frame during upscaling an option

### DIFF
--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -35,6 +35,7 @@ export interface UpscaleArgs<P extends Progress<O, PO>, O extends ResultFormat =
   progress?: P;
   progressOutput?: PO;
   signal?: AbortSignal;
+  awaitNextFrame?: boolean;
 }
 
 export type Layer = tf.layers.Layer;

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -443,8 +443,10 @@ export async function* upscale<P extends Progress<O, PO>, O extends ResultFormat
 }
 
 type TickFunction = (result?: YieldedIntermediaryValue) => Promise<void>;
-export const makeTick = (signal: AbortSignal): TickFunction => async result => {
-  await tf.nextFrame();
+export const makeTick = (signal: AbortSignal, awaitNextFrame?: boolean): TickFunction => async result => {
+  if (awaitNextFrame) {
+    await tf.nextFrame();
+  }
   if (isAborted(signal)) {
     // only dispose tensor if we are aborting; if aborted, the called function will have
     // no opportunity to dispose of its memory
@@ -459,12 +461,12 @@ export const makeTick = (signal: AbortSignal): TickFunction => async result => {
 
 export async function cancellableUpscale<P extends Progress<O, PO>, O extends ResultFormat = DEFAULT_OUTPUT, PO extends ResultFormat = undefined>(
   input: GetImageAsTensorInput,
-  { signal, ...args }: UpscaleArgs<P, O, PO>,
+  { signal, awaitNextFrame, ...args }: UpscaleArgs<P, O, PO>,
   internalArgs: ModelPackage & {
     signal: AbortSignal;
   },
 ): Promise<UpscaleResponse<O>> {
-  const tick = makeTick(signal || internalArgs.signal);
+  const tick = makeTick(signal || internalArgs.signal, awaitNextFrame);
   await tick();
   const upscaledPixels = await wrapGenerator(upscale(
     input,

--- a/test/integration/browser/upscale.ts
+++ b/test/integration/browser/upscale.ts
@@ -126,6 +126,7 @@ describe('Upscale Integration Tests', () => {
           patchSize: 4,
           padding: 2,
           output: 'base64',
+          awaitNextFrame: true,
           progress: (rate: number) => {
             const curTime = new Date().getTime();
             window['durations'].push(curTime - startTime);


### PR DESCRIPTION
There's a fundamental tension in regards to performance during an upscale operation.

By default, UpscalerJS called `await tf.nextFrame()` on every `tick` of its internal lifecycle. This enabled an operation to   minimize jankiness, by releasing the main UI thread as often as possible, but also contributes significant latency overhead to an upscale duration.

I'm not sure that we can say for sure which to prioritize more: speed of the overall upscale operation (which might be of priority in Node.js) or jankiness of the UI (which might be more important in the browser, but maybe not all the time).

Therefore, I think it makes sense to make this a user-configurable setting, whether to decide to release the UI thread on every internal `tick` or just plow ahead in the interest of the fastest overall speed possible.