### PR TITLE
Rename tensor input type

### DIFF
--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -20,9 +20,9 @@ export const loadImage = (src: string): Promise<HTMLImageElement> => new Promise
   img.onerror = () => reject(getInvalidImageError());
 });
 
-const fromPixels = (input: Exclude<GetImageAsTensorInput, string | tf.Tensor>) => tf.browser.fromPixelsAsync(input);
+const fromPixels = (input: Exclude<Input, string | tf.Tensor>) => tf.browser.fromPixelsAsync(input);
 
-const getTensorFromInput = async (input: GetImageAsTensorInput): Promise<tf.Tensor3D | tf.Tensor4D> => {
+const getTensorFromInput = async (input: Input): Promise<tf.Tensor3D | tf.Tensor4D> => {
   if (isTensor(input)) {
     return input;
   }
@@ -35,11 +35,9 @@ const getTensorFromInput = async (input: GetImageAsTensorInput): Promise<tf.Tens
   return fromPixels(input);
 };
 
-// // TODO: Bug with TFJS, ImageBitmap's types differ between browser.fromPixels and the exported type
-// type FromPixelsInputs = Exclude<tf.FromPixelsInputs['pixels'], 'ImageBitmap'> | ImageBitmap;
-export type GetImageAsTensorInput = tf.Tensor3D | tf.Tensor4D | string | tf.FromPixelsInputs['pixels'];
+export type Input = tf.Tensor3D | tf.Tensor4D | string | tf.FromPixelsInputs['pixels'];
 export const getImageAsTensor = async (
-  input: GetImageAsTensorInput,
+  input: Input,
 ): Promise<tf.Tensor4D> => {
   const tensor = await getTensorFromInput(input);
 
@@ -58,7 +56,7 @@ export const getImageAsTensor = async (
   throw getInvalidTensorError(tensor);
 };
 
-export const isHTMLImageElement = (pixels: GetImageAsTensorInput): pixels is HTMLImageElement => {
+export const isHTMLImageElement = (pixels: Input): pixels is HTMLImageElement => {
   try {
     return pixels instanceof HTMLImageElement;
   } catch (err) {

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -24,10 +24,10 @@ export const getInvalidChannelsOfTensor = (input: tf.Tensor): Error => new Error
   `Full tensor shape: ${JSON.stringify(input.shape)}`,
 ].join(' '));
 
-const isUint8Array = (input: GetImageAsTensorInput): input is Uint8Array => input.constructor === Uint8Array;
-const isBuffer = (input: GetImageAsTensorInput): input is Buffer => input.constructor === Buffer;
+const isUint8Array = (input: Input): input is Uint8Array => input.constructor === Uint8Array;
+const isBuffer = (input: Input): input is Buffer => input.constructor === Buffer;
 
-const getTensorFromInput = (input: GetImageAsTensorInput): tf.Tensor3D | tf.Tensor4D => {
+const getTensorFromInput = (input: Input): tf.Tensor3D | tf.Tensor4D => {
   if (isUint8Array(input)) {
     return tf.node.decodeImage(input);
   }
@@ -56,11 +56,11 @@ const getTensorFromInput = (input: GetImageAsTensorInput): tf.Tensor3D | tf.Tens
   throw getInvalidInput(input); 
 };
 
-export type GetImageAsTensorInput = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
+export type Input = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
 
 /* eslint-disable @typescript-eslint/require-await */
 export const getImageAsTensor = async (
-  input: GetImageAsTensorInput,
+  input: Input,
 ): Promise<tf.Tensor4D> => {
   const tensor = getTensorFromInput(input);
 

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -6,7 +6,7 @@ import type {
   TENSOR,
   YieldedIntermediaryValue,
  } from './types';
-import { getImageAsTensor, tensorAsBase64, GetImageAsTensorInput, } from './image.generated';
+import { getImageAsTensor, tensorAsBase64, Input, } from './image.generated';
 import { 
   wrapGenerator, 
   warn, 
@@ -371,31 +371,31 @@ export async function* predict(
 // if given a tensor, we copy it; otherwise, we pass input through unadulterated
 // this allows us to safely dispose of memory ourselves without having to manage
 // what input is in which format
-export const getCopyOfInput = (input: GetImageAsTensorInput): GetImageAsTensorInput => (isTensor(input) ? input.clone() : input);
+export const getCopyOfInput = (input: Input): Input => (isTensor(input) ? input.clone() : input);
 
 export function upscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   args: Omit<PrivateUpscaleArgs, 'output'> & {
     output: BASE64;
   },
   modelPackage: ModelPackage,
   ): AsyncGenerator<YieldedIntermediaryValue, string>;
 export function upscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   args: Omit<PrivateUpscaleArgs, 'output'> & {
     output: TENSOR;
   },
   modelPackage: ModelPackage,
   ): AsyncGenerator<YieldedIntermediaryValue, tf.Tensor3D>;
 export function upscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   args: Omit<PrivateUpscaleArgs, 'output'> & {
     output: BASE64 | TENSOR;
   },
   modelPackage: ModelPackage,
   ): AsyncGenerator<YieldedIntermediaryValue, string | tf.Tensor3D>;
 export async function* upscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   args: Omit<PrivateUpscaleArgs, 'output'> & {
     output: BASE64 | TENSOR;
   },
@@ -441,28 +441,28 @@ export async function* upscale(
 }
 
 export function cancellableUpscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   { signal, awaitNextFrame, ...args }: Omit<PrivateUpscaleArgs, 'output'> & { output: TENSOR},
   internalArgs: ModelPackage & {
     signal: AbortSignal;
   },
   ): Promise<tf.Tensor3D>;
 export function cancellableUpscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   { signal, awaitNextFrame, ...args }: Omit<PrivateUpscaleArgs, 'output'> & { output: BASE64},
   internalArgs: ModelPackage & {
     signal: AbortSignal;
   },
 ): Promise<string>;
 export function cancellableUpscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   { signal, awaitNextFrame, ...args }: Omit<PrivateUpscaleArgs, 'output'> & { output: BASE64 | TENSOR },
   internalArgs: ModelPackage & {
     signal: AbortSignal;
   },
 ): Promise<tf.Tensor3D | string>;
 export async function cancellableUpscale(
-  input: GetImageAsTensorInput,
+  input: Input,
   { signal, awaitNextFrame, ...args }: Omit<PrivateUpscaleArgs, 'output'> & { output: BASE64 | TENSOR},
   internalArgs: ModelPackage & {
     signal: AbortSignal;

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -29,7 +29,7 @@ import { getUpscaleOptions, } from './args.generated';
 import { loadModel, } from './loadModel.generated';
 import { cancellableWarmup, } from './warmup';
 import { cancellableUpscale, } from './upscale';
-import type { GetImageAsTensorInput, } from './image.generated';
+import type { Input, } from './image.generated';
 import type { ModelDefinitionObjectOrFn, } from '@upscalerjs/core';
 import { getModel, } from './utils';
 
@@ -109,30 +109,30 @@ export class Upscaler {
    * @returns an upscaled image.
    */
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output: TENSOR; progress?: MultiArgStringProgress; progressOutput: BASE64 },
   ): Promise<tf.Tensor3D>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: BASE64; progress?: MultiArgTensorProgress; progressOutput: TENSOR },
   ): Promise<string>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output: TENSOR; progress?: MultiArgTensorProgress; progressOutput?: unknown },
   ): Promise<tf.Tensor3D>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: BASE64; progress?: MultiArgStringProgress; progressOutput?: unknown },
   ): Promise<string>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: TENSOR | BASE64; progress?: MultiArgStringProgress | MultiArgTensorProgress; progressOutput?: unknown },
   ): Promise<tf.Tensor3D | string>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
   ): Promise<string>;
   public async upscale(
-    image: GetImageAsTensorInput,
+    image: Input,
     options?: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: unknown; progress?: MultiArgStringProgress | MultiArgTensorProgress; progressOutput?: unknown },
   ) {
     await this._ready;


### PR DESCRIPTION
Renames `GetImageAsTensorInput` to simply `Input`.