### PR TITLE
Add support for custom ops

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,13 @@ export interface ModelDefinition {
    */
   customLayers?: CustomLayer[];
   /**
+   * Custom ops for the model. You can learn more about custom ops [here](https://www.tensorflow.org/js/guide/custom_ops_kernels_gradients).
+   */
+  customOps?: ({
+    name: string;
+    op: tf.OpExecutor;
+  })[];
+  /**
    * @hidden
    */
   meta?: Meta;

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -37,6 +37,12 @@ export const registerCustomLayers = (modelDefinition: ModelDefinition): void => 
       tf.serialization.registerClass(layer);
     });
   }
+
+  if (modelDefinition.customOps) {
+    modelDefinition.customOps.forEach(({ name, op, }) => {
+      tf.registerOp(name, op);
+    });
+  }
 };
 
 export const warn = (msg: string | string[]): void => {


### PR DESCRIPTION
Add the ability for a model to define a set of custom ops, if Tensorflow.js does not support those ops.

The MAXIM family of models requires this.