### PR TITLE
Add support for input size

### DIFF
--- a/docs/docs/documentation/troubleshooting.md
+++ b/docs/docs/documentation/troubleshooting.md
@@ -193,3 +193,11 @@ If it has an entry like below, it's a `graph` model:
 ```json
 {"format": "graph-model", 
 ```
+
+## Error with Model Input Shape
+
+This error implies that the given model does not have an input layer compatible with a rank 4 tensor. It may be expected a rank 3 tensor, or something else entirely.
+
+UpscalerJS only supports models whose input layers are set up to accept rank 4 tensors.
+
+If you believe this is in error, or you have a particular use case you think would be appropriate for UpscalerJS, [please open a Github issue](https://github.com/thekevinscott/UpscalerJS/issues/new/choose).

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -10,6 +10,7 @@ import {
   hasValidChannels,
   isValidRange,
   isNumber,
+  isShape4D,
 } from './index';
 
 jest.mock('@tensorflow/tfjs', () => ({
@@ -151,5 +152,31 @@ describe('isValidRange', () => {
 
   it('returns true if it gets an array with two numbers', () => {
     expect(isValidRange([1,2])).toEqual(true);
+  });
+});
+
+describe('isShape4D', () => {
+  it('returns false if given an undefined', () => {
+    expect(isShape4D(undefined)).toEqual(false);
+  });
+
+  it('returns false if given a non-array', () => {
+    expect(isShape4D(2)).toEqual(false);
+  });
+
+  it('returns false if given an array of 3 numbers', () => {
+    expect(isShape4D([1,2,3])).toEqual(false);
+  });
+
+  it('returns false if given an array of 5 numbers', () => {
+    expect(isShape4D([1,2,3,4,5])).toEqual(false);
+  });
+
+  it('returns false if given an array of not all numbers', () => {
+    expect(isShape4D([1,2,3,'foo'])).toEqual(false);
+  });
+
+  it('returns true if given an array of all numbers', () => {
+    expect(isShape4D([1,2,3,4])).toEqual(false);
   });
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -173,10 +173,14 @@ describe('isShape4D', () => {
   });
 
   it('returns false if given an array of not all numbers', () => {
-    expect(isShape4D([1,2,3,'foo'])).toEqual(false);
+    expect(isShape4D([1,null,3,'foo'])).toEqual(false);
   });
 
   it('returns true if given an array of all numbers', () => {
     expect(isShape4D([1,2,3,4])).toEqual(false);
+  });
+
+  it('returns true if given an array containing nulls', () => {
+    expect(isShape4D([null, null, null, 3])).toEqual(false);
   });
 });

--- a/packages/core/src/index.test.ts
+++ b/packages/core/src/index.test.ts
@@ -177,10 +177,10 @@ describe('isShape4D', () => {
   });
 
   it('returns true if given an array of all numbers', () => {
-    expect(isShape4D([1,2,3,4])).toEqual(false);
+    expect(isShape4D([1,2,3,4])).toEqual(true);
   });
 
   it('returns true if given an array containing nulls', () => {
-    expect(isShape4D([null, null, null, 3])).toEqual(false);
+    expect(isShape4D([null, null, null, 3])).toEqual(true);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,12 +31,10 @@ export interface CustomOp {
 export type Shape4D = [null | number, number, number, number];
 export const isShape4D = (shape?: unknown): shape is Shape4D => {
   if (!Boolean(shape) || !Array.isArray(shape) || shape.length !== 4) {
-    console.log('naw!')
     return false;
   }
   for (const val of shape) {
     if (val !== null && typeof val !== 'number') {
-      console.log(val, 'naw')
       return false;
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,19 @@ export interface CustomOp {
   op: OpExecutor;
 }
 
+export type Shape4D = [number, number, number, number];
+export const isShape4D = (shape?: unknown): shape is Shape4D => {
+  if (!Boolean(shape) || !Array.isArray(shape) || shape.length !== 4) {
+    return false;
+  }
+  for (const val of shape) {
+    if (typeof val !== 'number') {
+      return false;
+    }
+  }
+  return true;
+};
+
 export interface ModelDefinition {
   /**
    * Path to a model.json file.
@@ -41,10 +54,6 @@ export interface ModelDefinition {
    * The scale of the model. For super resolution models, should match the scale at which the model was trained.
    */
   scale?: number;
-  /**
-   * The expected input size of the model. Should be a single number representing a square size.
-   */
-  inputSize?: number;
   /**
    * @hidden
    * 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,7 +40,11 @@ export interface ModelDefinition {
   /**
    * The scale of the model. For super resolution models, should match the scale at which the model was trained.
    */
-  scale: number;
+  scale?: number;
+  /**
+   * The expected input size of the model. Should be a single number representing a square size.
+   */
+  inputSize?: number;
   /**
    * @hidden
    * 
@@ -88,7 +92,7 @@ export type ModelDefinitionFn = (tf: TF) => ModelDefinition;
 
 export type ModelDefinitionObjectOrFn = ModelDefinitionFn | ModelDefinition;
 
-export type IsTensor<T extends tfBrowser.Tensor> = (pixels: Tensor) => pixels is T;
+export type IsTensor<T extends tf.Tensor> = (pixels: Tensor) => pixels is T;
 export function makeIsNDimensionalTensor<T extends Tensor>(rank: number): IsTensor<T> {
   function fn(pixels: Tensor): pixels is T {
     try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,10 +31,12 @@ export interface CustomOp {
 export type Shape4D = [null | number, number, number, number];
 export const isShape4D = (shape?: unknown): shape is Shape4D => {
   if (!Boolean(shape) || !Array.isArray(shape) || shape.length !== 4) {
+    console.log('naw!')
     return false;
   }
   for (const val of shape) {
     if (val !== null && typeof val !== 'number') {
+      console.log(val, 'naw')
       return false;
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,13 +28,13 @@ export interface CustomOp {
   op: OpExecutor;
 }
 
-export type Shape4D = [number, number, number, number];
+export type Shape4D = [null | number, number, number, number];
 export const isShape4D = (shape?: unknown): shape is Shape4D => {
   if (!Boolean(shape) || !Array.isArray(shape) || shape.length !== 4) {
     return false;
   }
   for (const val of shape) {
-    if (typeof val !== 'number') {
+    if (val !== null && typeof val !== 'number') {
       return false;
     }
   }

--- a/packages/upscalerjs/src/args.browser.ts
+++ b/packages/upscalerjs/src/args.browser.ts
@@ -1,6 +1,6 @@
-import { ModelDefinition, } from "@upscalerjs/core";
 import { parsePatchAndInputSizes, } from "./utils";
 import { BASE64, UpscaleArgs, TENSOR, PrivateUpscaleArgs, } from "./types";
+import { tf, } from "./dependencies.generated";
 
 const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   if (output === 'tensor') {
@@ -9,14 +9,14 @@ const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   return 'base64';
 };
 
-export function getUpscaleOptions(modelDefinition: ModelDefinition, {
+export function getUpscaleOptions(model: tf.LayersModel | tf.GraphModel, {
   output,
   progressOutput,
   ...options
 }: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
   return {
     ...options,
-    ...parsePatchAndInputSizes(modelDefinition, options),
+    ...parsePatchAndInputSizes(model, options),
     output: getOutputOption(output),
     progressOutput: getOutputOption(progressOutput || output),
   };

--- a/packages/upscalerjs/src/args.browser.ts
+++ b/packages/upscalerjs/src/args.browser.ts
@@ -1,3 +1,5 @@
+import { ModelDefinition, } from "@upscalerjs/core";
+import { parsePatchAndInputSizes, } from "./utils";
 import { BASE64, UpscaleArgs, TENSOR, PrivateUpscaleArgs, } from "./types";
 
 const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
@@ -7,10 +9,15 @@ const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   return 'base64';
 };
 
-export function getUpscaleOptions(options: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
+export function getUpscaleOptions(modelDefinition: ModelDefinition, {
+  output,
+  progressOutput,
+  ...options
+}: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
   return {
     ...options,
-    output: getOutputOption(options.output),
-    progressOutput: getOutputOption(options.progressOutput || options.output),
+    ...parsePatchAndInputSizes(modelDefinition, options),
+    output: getOutputOption(output),
+    progressOutput: getOutputOption(progressOutput || output),
   };
 }

--- a/packages/upscalerjs/src/args.node.ts
+++ b/packages/upscalerjs/src/args.node.ts
@@ -1,3 +1,5 @@
+import { ModelDefinition, } from "@upscalerjs/core";
+import { parsePatchAndInputSizes, } from "./utils";
 import { BASE64, UpscaleArgs, TENSOR, PrivateUpscaleArgs, } from "./types";
 
 const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
@@ -7,10 +9,15 @@ const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   return 'tensor';
 };
 
-export function getUpscaleOptions(options: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
+export function getUpscaleOptions(modelDefinition: ModelDefinition, {
+  output,
+  progressOutput,
+  ...options
+}: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
   return {
     ...options,
-    output: getOutputOption(options.output),
-    progressOutput: getOutputOption(options.progressOutput || options.output),
+    ...parsePatchAndInputSizes(modelDefinition, options),
+    output: getOutputOption(output),
+    progressOutput: getOutputOption(progressOutput || output),
   };
 }

--- a/packages/upscalerjs/src/args.node.ts
+++ b/packages/upscalerjs/src/args.node.ts
@@ -1,6 +1,6 @@
-import { ModelDefinition, } from "@upscalerjs/core";
 import { parsePatchAndInputSizes, } from "./utils";
 import { BASE64, UpscaleArgs, TENSOR, PrivateUpscaleArgs, } from "./types";
+import { tf, } from "./dependencies.generated";
 
 const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   if (output === 'base64') {
@@ -9,14 +9,14 @@ const getOutputOption = (output?: unknown): TENSOR | BASE64 => {
   return 'tensor';
 };
 
-export function getUpscaleOptions(modelDefinition: ModelDefinition, {
+export function getUpscaleOptions(model: tf.LayersModel | tf.GraphModel, {
   output,
   progressOutput,
   ...options
 }: Omit<UpscaleArgs, 'output' | 'progressOutput'> & { output?: unknown; progressOutput?: unknown } = {}): PrivateUpscaleArgs {
   return {
     ...options,
-    ...parsePatchAndInputSizes(modelDefinition, options),
+    ...parsePatchAndInputSizes(model, options),
     output: getOutputOption(output),
     progressOutput: getOutputOption(progressOutput || output),
   };

--- a/packages/upscalerjs/src/isLayersModel.test.ts
+++ b/packages/upscalerjs/src/isLayersModel.test.ts
@@ -1,0 +1,13 @@
+import * as tfn from '@tensorflow/tfjs-node';
+import { 
+  isLayersModel,
+} from './isLayersModel';
+
+describe('isLayersModel', () => {
+  it('returns true if given a layers model', () => {
+    const model = tfn.sequential();
+    model.add(tfn.layers.dense({units: 1, inputShape: [1]}));
+    model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
+    expect(isLayersModel(model)).toEqual(true);
+  });
+});

--- a/packages/upscalerjs/src/isLayersModel.ts
+++ b/packages/upscalerjs/src/isLayersModel.ts
@@ -1,0 +1,3 @@
+import { tf, } from './dependencies.generated';
+
+export const isLayersModel = (model: tf.LayersModel | tf.GraphModel): model is tf.LayersModel => model instanceof tf.LayersModel;

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -394,7 +394,7 @@ export async function* predict(
     // https://github.com/tensorflow/tfjs/issues/1125
     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const squeezedTensor = processAndDisposeOfTensor(upscaledTensor!, t => trimInput(imageSize, scale, t)).squeeze() as tf.Tensor3D;
+    const squeezedTensor = processAndDisposeOfTensor(upscaledTensor!, trimInput(imageSize, scale)).squeeze() as tf.Tensor3D;
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
     return squeezedTensor;
   }
@@ -405,7 +405,7 @@ export async function* predict(
 
   const prediction = model.predict(pixels) as tf.Tensor4D;
   yield [prediction,];
-  const postprocessedTensor = processAndDisposeOfTensor(prediction, modelDefinition.postprocess, t => trimInput(imageSize, scale, t));
+  const postprocessedTensor = processAndDisposeOfTensor(prediction, modelDefinition.postprocess, trimInput(imageSize, scale));
 
   // https://github.com/tensorflow/tfjs/issues/1125
   /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -5,7 +5,6 @@ import type {
   BASE64,
   TENSOR,
   YieldedIntermediaryValue,
-  Shape4D,
  } from './types';
 import { checkValidEnvironment, getImageAsTensor, tensorAsBase64, Input, } from './image.generated';
 import {
@@ -24,6 +23,7 @@ import {
   isTensor,
   isThreeDimensionalTensor,
   isFourDimensionalTensor,
+  Shape4D,
  } from '@upscalerjs/core';
 import { makeTick, } from './makeTick';
 import { GraphModel, LayersModel, } from '@tensorflow/tfjs';

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -18,6 +18,7 @@ import {
   scaleIncomingPixels,
   padInput,
   trimInput,
+  getInputShape,
  } from './utils';
 import {
   isTensor,
@@ -451,8 +452,9 @@ export async function* upscale(
   yield startingPixels;
 
   const imageSize = startingPixels.shape;
+  const inputSize = getInputShape(model);
 
-  const preprocessedPixels = processAndDisposeOfTensor(startingPixels, modelDefinition.preprocess, scaleIncomingPixels(modelDefinition.inputRange), padInput(modelDefinition));
+  const preprocessedPixels = processAndDisposeOfTensor(startingPixels, modelDefinition.preprocess, scaleIncomingPixels(modelDefinition.inputRange), padInput(inputSize));
   yield preprocessedPixels;
 
   const gen = predict(

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -394,8 +394,13 @@ export async function* predict(
     // https://github.com/tensorflow/tfjs/issues/1125
     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    const squeezedTensor = processAndDisposeOfTensor(upscaledTensor!, trimInput(imageSize, scale)).squeeze() as tf.Tensor3D;
+    const processedUpscaledTensor = processAndDisposeOfTensor(upscaledTensor!.clone(), trimInput(imageSize, scale));
+    upscaledTensor?.dispose();
+    yield [processedUpscaledTensor,];
+
+    const squeezedTensor = processedUpscaledTensor!.squeeze() as tf.Tensor3D;
     /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    processedUpscaledTensor!.dispose();
     return squeezedTensor;
   }
 
@@ -405,7 +410,10 @@ export async function* predict(
 
   const prediction = model.predict(pixels) as tf.Tensor4D;
   yield [prediction,];
-  const postprocessedTensor = processAndDisposeOfTensor(prediction, modelDefinition.postprocess, trimInput(imageSize, scale));
+  const postprocessedTensor = processAndDisposeOfTensor(prediction.clone(), modelDefinition.postprocess, trimInput(imageSize, scale));
+
+  prediction.dispose();
+  yield [postprocessedTensor,];
 
   // https://github.com/tensorflow/tfjs/issues/1125
   /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
@@ -413,6 +421,98 @@ export async function* predict(
   postprocessedTensor.dispose();
   return squeezedTensor;
 }
+
+// /* eslint-disable @typescript-eslint/require-await */
+// export async function* predict2(
+//   pixels: tf.Tensor4D,
+//   { output, progress, patchSize: originalPatchSize, padding, progressOutput, }: PrivateUpscaleArgs,
+//   {
+//     model,
+//     modelDefinition,
+//   }: ModelPackage,
+//   {
+//     imageSize,
+//   }: {
+//     imageSize: Shape4D;
+//   }
+// ): AsyncGenerator<YieldedIntermediaryValue, tf.Tensor3D> {
+//   if (patchSize) {
+//     const [height, width,] = pixels.shape.slice(1);
+//     const { rows, columns, } = getRowsAndColumns(pixels, patchSize);
+//     yield;
+//     let upscaledTensor: undefined | tf.Tensor4D;
+//     const total = rows * columns;
+//     for (let row = 0; row < rows; row++) {
+//       let colTensor: undefined | tf.Tensor4D;
+//       yield [colTensor, upscaledTensor,];
+//       for (let col = 0; col < columns; col++) {
+//         const { origin, size, sliceOrigin, sliceSize, } = getTensorDimensions({
+//           row,
+//           col,
+//           patchSize,
+//           padding,
+//           height,
+//           width,
+//         });
+//         yield [upscaledTensor, colTensor,];
+//         const slicedPixels = pixels.slice(
+//           [0, origin[0], origin[1],],
+//           [-1, size[0], size[1],],
+//         );
+//         yield [upscaledTensor, colTensor, slicedPixels,];
+//         const prediction = executeModel(model, slicedPixels);
+//         slicedPixels.dispose();
+//         yield [upscaledTensor, colTensor, prediction,];
+
+//         const startSlice = [0, sliceOrigin[0] * scale, sliceOrigin[1] * scale,];
+//         const endSlice = [-1, sliceSize[0] * scale, sliceSize[1] * scale,];
+//         const slicedPrediction = prediction.slice(
+//           startSlice, endSlice,
+//         );
+//         prediction.dispose();
+//         yield [upscaledTensor, colTensor, slicedPrediction,];
+//         const processedPrediction = processAndDisposeOfTensor(slicedPrediction, modelDefinition.postprocess);
+//         yield [upscaledTensor, colTensor, processedPrediction,];
+
+//         if (progress !== undefined && isProgress(progress)) {
+//           const percent = getPercentageComplete(row, col, columns, total);
+//           if (isSingleArgProgress(progress)) {
+//             progress(percent);
+//           } else {
+//             /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+//             const squeezedTensor = processedPrediction.squeeze() as tf.Tensor3D;
+//             if (isMultiArgTensorProgress(progress, output, progressOutput)) {
+//               // because we are returning a tensor, we cannot safely dispose of it
+//               progress(percent, squeezedTensor, row, col);
+//             } else {
+//               // because we are returning a string, we can safely dispose of our tensor
+//               const src = tensorAsBase64(squeezedTensor, modelDefinition.outputRange);
+//               squeezedTensor.dispose();
+//               progress(percent, src, row, col);
+//             }
+//           }
+//         }
+//         yield [upscaledTensor, colTensor, processedPrediction,];
+
+//         colTensor = concatTensors<tf.Tensor4D>([colTensor, processedPrediction,], 2);
+//         processedPrediction.dispose();
+//         yield [upscaledTensor, colTensor,];
+//       }
+
+//       upscaledTensor = concatTensors<tf.Tensor4D>([upscaledTensor, colTensor,], 1);
+
+//       /* eslint-disable @typescript-eslint/no-non-null-assertion */
+//       colTensor!.dispose();
+//       yield [upscaledTensor,];
+//     }
+//     // https://github.com/tensorflow/tfjs/issues/1125
+//     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+//     /* eslint-disable @typescript-eslint/no-non-null-assertion */
+//     const squeezedTensor = tf.tidy(() => processAndDisposeOfTensor(upscaledTensor!, trimInput(imageSize, scale)).squeeze() as tf.Tensor3D);
+//     /* eslint-disable @typescript-eslint/no-non-null-assertion */
+//     return squeezedTensor;
+//   }
+// }
 
 // if given a tensor, we copy it; otherwise, we pass input through unadulterated
 // this allows us to safely dispose of memory ourselves without having to manage

--- a/packages/upscalerjs/src/upscaler.test.ts
+++ b/packages/upscalerjs/src/upscaler.test.ts
@@ -65,6 +65,9 @@ describe('Upscaler', () => {
         },
         model: {
           predict: jest.fn(() => _tf.ones([1,2,2,3])),
+          inputs: [{
+            shape: [null, null, null, 3],
+          }]
         } as unknown as LayersModel,
       };
     });

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -137,7 +137,7 @@ export class Upscaler {
   ) {
     await this._ready;
     const { model, modelDefinition, } = await this._model;
-    return cancellableUpscale(image, getUpscaleOptions(options), {
+    return cancellableUpscale(image, getUpscaleOptions(model, options), {
       model,
       modelDefinition,
       signal: this._abortController.signal,

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -572,19 +572,19 @@ describe('padInput', () => {
 describe('trimInput', () => {
   it('just returns the input if width and height are equal to pixels shape', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    expect(trimInput([1, 4, 4, 3], 1, t)).toEqual(t);
+    expect(trimInput([1, 4, 4, 3], 1)(t)).toEqual(t);
   });
 
   it('returns a sliced image if image height is smaller than pixels height', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    const result = trimInput([1, 2, 4, 3], 1, t);
+    const result = trimInput([1, 2, 4, 3], 1)(t);
     expect(result).not.toEqual(t);
     expect(result.shape).toEqual([1, 2, 4, 3]);
   });
 
   it('returns a sliced image if image width is smaller than pixels width', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    const result = trimInput([1, 4, 2, 3], 1, t);
+    const result = trimInput([1, 4, 2, 3], 1)(t);
     expect(result).not.toEqual(t);
     expect(result.shape).toEqual([1, 4, 2, 3]);
   });

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -1,6 +1,6 @@
 import { GraphModel, Tensor3D, Tensor4D, ones } from '@tensorflow/tfjs-node';
-import { tensor, OpExecutor } from '@tensorflow/tfjs-node';
-import { tf, tf as _tf, } from './dependencies.generated';
+import { LayersModel, tensor } from '@tensorflow/tfjs-node';
+import { tf as _tf, } from './dependencies.generated';
 import { mock, mockFn } from '../../../test/lib/shared/mockers';
 import { 
   tensorAsClampedArray,
@@ -22,10 +22,12 @@ import {
   WARNING_INPUT_SIZE_AND_PATCH_SIZE,
   padInput,
   trimInput,
-  isLayersModel as _isLayersModel,
   getInputShape,
   ERROR_WITH_MODEL_INPUT_SHAPE,
 } from './utils';
+import {
+  isLayersModel as _isLayersModel,
+} from './isLayersModel';
 import { isShape4D as _isShape4D, CustomOp, ModelDefinition, ModelDefinitionFn } from '@upscalerjs/core';
 
 jest.mock('./dependencies.generated', () => {
@@ -44,11 +46,19 @@ jest.mock('./dependencies.generated', () => {
   };
 });
 
+jest.mock('./isLayersModel', () => {
+  const { isLayersModel, ...rest } = jest.requireActual('./isLayersModel');
+  return {
+    ...rest,
+    isLayersModel: jest.fn().mockImplementation(isLayersModel),
+  };
+});
+
 jest.mock('@upscalerjs/core', () => {
-  const { ...core } = jest.requireActual('@upscalerjs/core');
+  const { isShape4D, ...core } = jest.requireActual('@upscalerjs/core');
   return {
     ...core,
-    isShape4D: jest.fn(),
+    isShape4D: jest.fn().mockImplementation(isShape4D),
   };
 });
 
@@ -519,12 +529,24 @@ describe('scaleIncomingPixels', () => {
 
 describe('parsePatchAndInputSizes', () => {
   const origWarn = console.warn;
+
+  beforeEach(() => {
+    isLayersModel.mockImplementation(() => true);
+    isShape4D.mockImplementation(() => true);
+  });
+
   afterEach(() => {
     console.warn = origWarn;
+    isLayersModel.mockClear();
+    isShape4D.mockClear();
   });
 
   it('passes patchSize and padding through unadulterated', () => {
-    expect(parsePatchAndInputSizes({ path: 'foo' }, { patchSize: 9, padding: 8 })).toEqual({
+    expect(parsePatchAndInputSizes({
+      layers: [{
+        batchInputShape: [null, null, null, 3],
+      }],
+    } as any as LayersModel, { patchSize: 9, padding: 8 })).toEqual({
       patchSize: 9,
       padding: 8,
     })
@@ -534,49 +556,61 @@ describe('parsePatchAndInputSizes', () => {
     const fn = jest.fn();
     console.warn = fn;
     warn('foo');
-    parsePatchAndInputSizes({ path: 'foo', inputSize: 9 }, { patchSize: 9, padding: 8 });
+    parsePatchAndInputSizes({
+      layers: [{
+        batchInputShape: [null, 9, 9, 3],
+      }],
+    } as any as LayersModel, { patchSize: 9, padding: 8 });
     expect(fn).toHaveBeenCalledWith(WARNING_INPUT_SIZE_AND_PATCH_SIZE);
   });
 });
 
 describe('padInput', () => {
+  beforeEach(() => {
+    isShape4D.mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    isShape4D.mockClear();
+  });
+
   it('just returns the input if no inputSize is specified', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    expect(padInput({ path: 'foo' })(t)).toEqual(t);
+    expect(padInput()(t)).toEqual(t);
   });
 
   it('just returns the input if inputSize is less than the shape of the tensor', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    expect(padInput({ path: 'foo', inputSize: 2 })(t)).toEqual(t);
+    expect(padInput([null, 2, 2, 3])(t)).toEqual(t);
   });
 
   it('just returns the input if inputSize is equal to the width of the tensor', () => {
     const t = ones([1, 4, 8, 3]) as Tensor4D;
-    expect(padInput({ path: 'foo', inputSize: 4 })(t)).toEqual(t);
+    expect(padInput([null, 4, 4, 3])(t)).toEqual(t);
   });
 
   it('just returns the input if inputSize is equal to the height of the tensor', () => {
     const t = ones([1, 8, 4, 3]) as Tensor4D;
-    expect(padInput({ path: 'foo', inputSize: 4 })(t)).toEqual(t);
+    expect(padInput([null, 4, 4, 3])(t)).toEqual(t);
   });
 
   it('returns an image with padding if input size is greater than image', () => {
     const t = ones([1, 4, 4, 3]) as Tensor4D;
-    const result = padInput({ path: 'foo', inputSize: 6 })(t);
+    const result = padInput([null, 6, 6, 3])(t);
     expect(result).not.toEqual(t);
     expect(result.shape).toEqual([1, 6, 6, 3]);
   });
 
   it('returns an image with padding if input size is greater than the height', () => {
     const t = ones([1, 4, 8, 3]) as Tensor4D;
-    const result = padInput({ path: 'foo', inputSize: 6 })(t);
+    const result = padInput([null, 6, 6, 3])(t);
     expect(result).not.toEqual(t);
     expect(result.shape).toEqual([1, 6, 8, 3]);
   });
 
   it('returns an image with padding if input size is greater than the width', () => {
     const t = ones([1, 8, 4, 3]) as Tensor4D;
-    const result = padInput({ path: 'foo', inputSize: 6 })(t);
+    const result = padInput([null, 6, 6, 3])(t);
     expect(result).not.toEqual(t);
     expect(result.shape).toEqual([1, 8, 6, 3]);
   });
@@ -603,20 +637,11 @@ describe('trimInput', () => {
   });
 });
 
-describe('isLayersModel', () => {
-  it('returns true if given a layers model', () => {
-    const model = tf.sequential();
-    model.add(tf.layers.dense({units: 1, inputShape: [1]}));
-    model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
-    expect(isLayersModel(model)).toEqual(true);
-  });
-});
-
 describe('getInputShape', () => {
   afterEach(() => {
     isLayersModel.mockClear();
     isShape4D.mockClear();
-  })
+  });
 
   it('returns layers model input shape if it is a layers model', () => {
     isLayersModel.mockImplementation(() => true);
@@ -624,32 +649,25 @@ describe('getInputShape', () => {
       layers: [{
         batchInputShape: [1, 2, 3, 4],
       }],
-    } as any as tf.LayersModel).toEqual([1,2,3,4]));
+    } as any as LayersModel)).toEqual([1,2,3,4]);
   });
 
   it('returns graph model input shape if it is a layers model', () => {
     isLayersModel.mockImplementation(() => false);
     expect(getInputShape({
-      executor: {
-        graph: {
-          inputs: [{
-            attrParams: {
-              shape: {
-                value: [1, 2, 3, 4],
-              }
-            },
-          }],
-        },
-      }
-    } as any as tf.LayersModel).toEqual([1, 2, 3, 4]));
+      inputs: [{
+        shape: [1, 2, 3, 4],
+      }],
+    } as any as GraphModel)).toEqual([1, 2, 3, 4]);
   });
 
   it('throws if a model returns a non rank 4 shape', () => {
+    isShape4D.mockImplementation(() => false);
     isLayersModel.mockImplementation(() => true);
     expect(() => getInputShape({
       layers: [{
         batchInputShape: [1, 2, 3, 4, 5],
       }],
-    } as any as tf.LayersModel)).toThrow(ERROR_WITH_MODEL_INPUT_SHAPE([1,2,3,4,5]));
+    } as any as LayersModel)).toThrow(ERROR_WITH_MODEL_INPUT_SHAPE([1,2,3,4,5]));
   });
 });

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -186,9 +186,10 @@ export const padInput = (inputSize?: Shape4D) => (pixels: tf.Tensor4D): tf.Tenso
 };
 
 export const trimInput = (
+  imageSize: Shape4D,
   scale: number,
+) => (
   pixels: tf.Tensor4D
-  imageSize?: Shape4D,
 ): tf.Tensor4D => {
   const height = imageSize[1] * scale;
   const width = imageSize[2] * scale;


### PR DESCRIPTION
Some models have a fixed input size, for instance their input layer might be:

```[null, 256, 256, 3]```

Other models might have no set input size:

```[null,null,null,3]```

UpscalerJS should be smart enough to automatically handle both cases (and pad and trim images in the former case, as well as automatically switch into patch size mode).