### PR TITLE
Remove support for custom ops in the model definition

### DIFF
--- a/models/esrgan-legacy/src/gans.ts
+++ b/models/esrgan-legacy/src/gans.ts
@@ -53,6 +53,10 @@ const modelDefinition: ModelDefinitionFn = (tf: TF) => {
     static className = 'PixelShuffle';
   }
 
+  [MultiplyBeta, PixelShuffle,].forEach((layer) => {
+    tf.serialization.registerClass(layer);
+  });
+
   const modelDefinition: ModelDefinition = {
     scale: SCALE,
     path: 'models/gans/model.json',
@@ -65,7 +69,6 @@ const modelDefinition: ModelDefinitionFn = (tf: TF) => {
     },
     inputRange: [0, 1,],
     outputRange: [0, 1,],
-    customLayers: [MultiplyBeta, PixelShuffle,],
   };
 
   return modelDefinition;

--- a/models/esrgan-thick/src/utils/getModelDefinition.ts
+++ b/models/esrgan-thick/src/utils/getModelDefinition.ts
@@ -46,10 +46,13 @@ const getModelDefinition = (scale: Scale, modelFileName: string): ModelDefinitio
     return PixelShuffle;
   };
 
+  [MultiplyBeta, getPixelShuffle(scale),].forEach((layer) => {
+    tf.serialization.registerClass(layer);
+  });
+
   return {
     inputRange: [0, 1,],
     outputRange: [0, 1,],
-    customLayers: [MultiplyBeta, getPixelShuffle(scale),],
     scale,
     path: `models/${scale}x/model.json`,
     packageInformation: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,7 +2,7 @@ import * as tf from '@tensorflow/tfjs-core';
 import type * as tfBrowser from '@tensorflow/tfjs';
 import type * as tfNode from '@tensorflow/tfjs-node';
 import type * as tfNodeGpu from '@tensorflow/tfjs-node-gpu';
-import { Tensor, Tensor3D, Tensor4D, serialization, } from '@tensorflow/tfjs-core';
+import { Tensor, Tensor3D, Tensor4D, } from '@tensorflow/tfjs-core';
 
 export type TF = typeof tfBrowser | typeof tfNode | typeof tfNodeGpu;
 export type OpExecutor = tfBrowser.OpExecutor | tfNode.OpExecutor | tfNodeGpu.OpExecutor;
@@ -13,7 +13,6 @@ export interface PackageInformation {
   version: string;
 }
 
-type CustomLayer = Parameters<typeof serialization.registerClass>[0];
 export type Range = [number, number,];
 
 type MetaValue = string | number | Meta | null | undefined | boolean;
@@ -22,11 +21,6 @@ export type ModelType = 'graph' | 'layers';
 
 export type PreProcess = ProcessFn<Tensor4D>;
 export type PostProcess = ProcessFn<Tensor4D>;
-
-export interface CustomOp {
-  name: string;
-  op: OpExecutor;
-}
 
 export type Shape4D = [null | number, number, number, number];
 export const isShape4D = (shape?: unknown): shape is Shape4D => {
@@ -74,14 +68,6 @@ export interface ModelDefinition {
    * A function that processes the input image after being run through model inference. For example, you may need to convert floats to 0-255 integers.
    */
   postprocess?: PostProcess;
-  /**
-   * Custom layers for the model. You can learn more about custom layers [here](https://www.tensorflow.org/js/guide/models_and_layers#custom_layers).
-   */
-  customLayers?: CustomLayer[];
-  /**
-   * Custom ops for the model. You can learn more about custom ops [here](https://www.tensorflow.org/js/guide/custom_ops_kernels_gradients).
-   */
-  customOps?: CustomOp[];
   /**
     * Two numbers denoting the range in which the model expects number to be in the range of. Defaults to [0, 255].
     */

--- a/packages/upscalerjs/src/loadModel.browser.test.ts
+++ b/packages/upscalerjs/src/loadModel.browser.test.ts
@@ -10,7 +10,6 @@ import {
   loadModel,
 } from './loadModel.browser';
 import {
-  registerCustomLayers as _registerCustomLayers,
   getModelDefinitionError as _getModelDefinitionError,
   loadTfModel as _loadTfModel,
   ERROR_MODEL_DEFINITION_BUG,
@@ -30,10 +29,9 @@ jest.mock('./loadModel.browser', () => {
 });
 
 jest.mock('./utils', () => {
-  const { loadTfModel, getModelDefinitionError, registerCustomLayers, ...rest } = jest.requireActual('./utils');
+  const { loadTfModel, getModelDefinitionError, ...rest } = jest.requireActual('./utils');
   return {
     ...rest,
-    registerCustomLayers: jest.fn(registerCustomLayers),
     getModelDefinitionError: jest.fn(getModelDefinitionError),
     loadTfModel: jest.fn(loadTfModel),
   }
@@ -62,12 +60,10 @@ jest.mock('./dependencies.generated', () => {
 const tf = mock(_tf);
 const getModelDefinitionError = mockFn(_getModelDefinitionError);
 const isValidModelDefinition = mockFn(_isValidModelDefinition);
-const registerCustomLayers = mockFn(_registerCustomLayers);
 const loadTfModel = mockFn(_loadTfModel);
 
 describe('loadModel browser tests', () => {
   beforeEach(() => {
-    registerCustomLayers.mockClear();
     getModelDefinitionError.mockClear();
     isValidModelDefinition.mockClear();
     loadTfModel.mockClear();
@@ -196,7 +192,6 @@ describe('loadModel browser tests', () => {
       const model = 'foo' as unknown as LayersModel;
       loadTfModel.mockImplementation(async () => model);
       expect(loadTfModel).toHaveBeenCalledTimes(0);
-      expect(registerCustomLayers).toHaveBeenCalledTimes(0);
 
       const modelDefinition: ModelDefinition = {
         path: 'foo',
@@ -208,8 +203,6 @@ describe('loadModel browser tests', () => {
 
       expect(loadTfModel).toHaveBeenCalledTimes(1);
       expect(loadTfModel).toHaveBeenCalledWith(modelDefinition.path, 'layers');
-      expect(registerCustomLayers).toHaveBeenCalledTimes(1);
-      expect(registerCustomLayers).toHaveBeenCalledWith(modelDefinition);
 
       expect(result).toStrictEqual({
         modelDefinition,
@@ -223,7 +216,6 @@ describe('loadModel browser tests', () => {
       tf.loadLayersModel.mockImplementation(async () => 'layers model' as any);
       tf.loadGraphModel.mockImplementation(async () => model);
       expect(tf.loadLayersModel).toHaveBeenCalledTimes(0);
-      expect(registerCustomLayers).toHaveBeenCalledTimes(0);
 
       const modelDefinition: ModelDefinition = {
         path: 'foo',
@@ -235,8 +227,6 @@ describe('loadModel browser tests', () => {
 
       expect(loadTfModel).toHaveBeenCalledTimes(1);
       expect(loadTfModel).toHaveBeenCalledWith(modelDefinition.path, 'graph');
-      expect(registerCustomLayers).toHaveBeenCalledTimes(1);
-      expect(registerCustomLayers).toHaveBeenCalledWith(modelDefinition);
 
       expect(result).toStrictEqual({
         modelDefinition,

--- a/packages/upscalerjs/src/loadModel.browser.ts
+++ b/packages/upscalerjs/src/loadModel.browser.ts
@@ -5,7 +5,6 @@ import {
   ERROR_MODEL_DEFINITION_BUG,
   getModelDefinitionError,
   loadTfModel,
-  registerCustomLayers,
 } from './utils';
 import {
   isValidModelDefinition,
@@ -64,7 +63,6 @@ export const loadModel = async (
   } catch(err: unknown) {
     throw err instanceof ModelDefinitionValidationError ? getModelDefinitionError(err.type, modelDefinition) : new Error(ERROR_MODEL_DEFINITION_BUG);
   }
-  registerCustomLayers(modelDefinition);
 
   const model = await fetchModel(modelDefinition);
 

--- a/packages/upscalerjs/src/loadModel.node.test.ts
+++ b/packages/upscalerjs/src/loadModel.node.test.ts
@@ -11,7 +11,6 @@ import { resolver as _resolver } from './resolver';
 import type { ModelDefinition } from "@upscalerjs/core";
 import {
   getModelDefinitionError as _getModelDefinitionError,
-  registerCustomLayers as _registerCustomLayers,
   loadTfModel as _loadTfModel,
   ERROR_MODEL_DEFINITION_BUG,
 } from './utils';
@@ -21,10 +20,9 @@ import {
   MODEL_DEFINITION_VALIDATION_CHECK_ERROR_TYPE,
 } from '@upscalerjs/core';
 jest.mock('./utils', () => {
-  const { loadTfModel, getModuleFolder, getModelDefinitionError, registerCustomLayers, ...rest } = jest.requireActual('./utils');
+  const { loadTfModel, getModuleFolder, getModelDefinitionError, ...rest } = jest.requireActual('./utils');
   return {
     ...rest,
-    registerCustomLayers: jest.fn(registerCustomLayers),
     getModelDefinitionError: jest.fn(getModelDefinitionError),
     getModuleFolder: jest.fn(getModuleFolder),
     loadTfModel: jest.fn(loadTfModel),
@@ -61,7 +59,6 @@ const tf = mock(_tf);
 const resolver = mockFn(_resolver);
 const getModelDefinitionError = mockFn(_getModelDefinitionError);
 const isValidModelDefinition = mockFn(_isValidModelDefinition);
-const registerCustomLayers = mockFn(_registerCustomLayers);
 const loadTfModel = mockFn(_loadTfModel);
 
 const getResolver = (fn: () => string) => (fn) as unknown as typeof require.resolve;
@@ -70,7 +67,6 @@ describe('loadModel.node', () => {
   beforeEach(() => {
     getModelDefinitionError.mockClear();
     isValidModelDefinition.mockClear();
-    registerCustomLayers.mockClear();
     resolver.mockClear();
     tf.loadLayersModel.mockClear();
   });
@@ -130,14 +126,12 @@ describe('loadModel.node', () => {
     it('loads a valid layers model', async () => {
       resolver.mockImplementation(getResolver(() => './node_modules/baz'));
       isValidModelDefinition.mockImplementation(() => true);
-      registerCustomLayers.mockImplementation(() => { });
       loadTfModel.mockImplementation(async () => 'layers model' as any);
 
       const path = 'foo';
       const modelDefinition: ModelDefinition = { path, scale: 2, modelType: 'layers' };
 
       const response = await loadModel(modelDefinition);
-      expect(registerCustomLayers).toHaveBeenCalledTimes(1);
       expect(loadTfModel).toHaveBeenCalledWith(path, 'layers');
       expect(response).toEqual({
         model: 'layers model',
@@ -148,14 +142,12 @@ describe('loadModel.node', () => {
     it('loads a valid graph model', async () => {
       resolver.mockImplementation(getResolver(() => './node_modules/baz'));
       isValidModelDefinition.mockImplementation(() => true);
-      registerCustomLayers.mockImplementation(() => { });
       loadTfModel.mockImplementation(async () => 'graph model' as any);
 
       const path = 'foo';
       const modelDefinition: ModelDefinition = { path, scale: 2, modelType: 'graph' };
 
       const response = await loadModel(modelDefinition);
-      expect(registerCustomLayers).toHaveBeenCalledTimes(1);
       expect(loadTfModel).toHaveBeenCalledWith(path, 'graph');
       expect(response).toEqual({
         model: 'graph model',

--- a/packages/upscalerjs/src/loadModel.node.ts
+++ b/packages/upscalerjs/src/loadModel.node.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import type { ModelDefinition, } from "@upscalerjs/core";
-import { ERROR_MODEL_DEFINITION_BUG, getModelDefinitionError, loadTfModel, registerCustomLayers, } from './utils';
+import { ERROR_MODEL_DEFINITION_BUG, getModelDefinitionError, loadTfModel, } from './utils';
 import { resolver, } from './resolver';
 import { ModelPackage, } from './types';
 import {
@@ -43,7 +43,6 @@ export const loadModel = async (
   } catch(err: unknown) {
     throw err instanceof ModelDefinitionValidationError ? getModelDefinitionError(err.type, modelDefinition) : new Error(ERROR_MODEL_DEFINITION_BUG);
   }
-  registerCustomLayers(modelDefinition);
 
   const modelPath = getModelPath(modelDefinition);
   const model = await loadTfModel(modelPath, modelDefinition.modelType);

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -11,7 +11,6 @@ import {
   isMultiArgTensorProgress, 
   warn, 
   isAborted,
-  registerCustomLayers,
   ERROR_MISSING_MODEL_DEFINITION_PATH,
   getModel,
   ERROR_MODEL_DEFINITION_BUG,
@@ -32,7 +31,6 @@ import {
 import {
   isValidRange as _isValidRange,
   isShape4D as _isShape4D,
-  CustomOp,
   ModelDefinition,
   ModelDefinitionFn,
   MODEL_DEFINITION_VALIDATION_CHECK_ERROR_TYPE,
@@ -76,71 +74,6 @@ const tfSerialization = mock(_tf.serialization);
 const isLayersModel = mockFn(_isLayersModel);
 const isShape4D = mockFn(_isShape4D);
 const isValidRange = mockFn(_isValidRange);
-
-describe('registerCustomLayers', () => {
-  afterEach(() => {
-    tfSerialization.registerClass.mockClear();
-    tf.registerOp.mockClear();
-  });
-
-  it('does nothing if no custom layers are specified', () => {
-    tfSerialization.registerClass = jest.fn();
-    tf.registerOp = jest.fn();
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(0);
-    expect(tf.registerOp).toHaveBeenCalledTimes(0);
-    const modelDefinition: ModelDefinition = {
-      path: 'foo',
-      scale: 2,
-    };
-    registerCustomLayers(modelDefinition);
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(0);
-    expect(tf.registerOp).toHaveBeenCalledTimes(0);
-  });
-
-  it('registers custom layers if provided', () => {
-    tfSerialization.registerClass = jest.fn();
-    tf.registerOp = jest.fn();
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(0);
-    expect(tf.registerOp).toHaveBeenCalledTimes(0);
-    const modelDefinition: ModelDefinition = {
-      path: 'foo',
-      scale: 2,
-      customLayers: ['foo','bar','baz'] as Array<any>,
-    };
-    registerCustomLayers(modelDefinition);
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(3);
-    expect(tf.registerOp).toHaveBeenCalledTimes(0);
-  });
-
-  it('registers custom ops if provided', () => {
-    tfSerialization.registerClass = jest.fn();
-    tf.registerOp = jest.fn();
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(0);
-    expect(tf.registerOp).toHaveBeenCalledTimes(0);
-    const customOps: CustomOp[] = [
-      {
-        name: 'foo',
-        op: () => tensor([]),
-      },
-      {
-        name: 'bar',
-        op: () => tensor([]),
-      },
-      {
-        name: 'baz',
-        op: () => tensor([]),
-      },
-    ];
-    const modelDefinition: ModelDefinition = {
-      path: 'foo',
-      scale: 2,
-      customOps,
-    };
-    registerCustomLayers(modelDefinition);
-    expect(tfSerialization.registerClass).toHaveBeenCalledTimes(0);
-    expect(tf.registerOp).toHaveBeenCalledTimes(3);
-  });
-});
 
 describe('isAborted', () => {
   it('handles an undefined signal', () => {

--- a/packages/upscalerjs/src/utils.test.ts
+++ b/packages/upscalerjs/src/utils.test.ts
@@ -45,9 +45,6 @@ jest.mock('./dependencies.generated', () => {
       registerOp: jest.fn(),
       loadLayersModel: jest.fn(),
       loadGraphModel: jest.fn(),
-      serialization: {
-        registerClass: jest.fn(),
-      },
     },
   };
 });
@@ -70,7 +67,6 @@ jest.mock('@upscalerjs/core', () => {
 });
 
 const tf = mock(_tf);
-const tfSerialization = mock(_tf.serialization);
 const isLayersModel = mockFn(_isLayersModel);
 const isShape4D = mockFn(_isShape4D);
 const isValidRange = mockFn(_isValidRange);

--- a/packages/upscalerjs/src/utils.ts
+++ b/packages/upscalerjs/src/utils.ts
@@ -54,20 +54,6 @@ export function getModelDefinitionError(error: MODEL_DEFINITION_VALIDATION_CHECK
   }
 }
 
-export const registerCustomLayers = (modelDefinition: ModelDefinition): void => {
-  if (modelDefinition.customLayers) {
-    modelDefinition.customLayers.forEach((layer) => {
-      tf.serialization.registerClass(layer);
-    });
-  }
-
-  if (modelDefinition.customOps) {
-    modelDefinition.customOps.forEach(({ name, op, }) => {
-      tf.registerOp(name, op);
-    });
-  }
-};
-
 export const warn = (msg: string | string[]): void => {
   console.warn(Array.isArray(msg) ? msg.join('\n') : msg);// skipcq: JS-0002
 };

--- a/scripts/package-scripts/benchmark/performance/utils/SpeedBenchmarker.ts
+++ b/scripts/package-scripts/benchmark/performance/utils/SpeedBenchmarker.ts
@@ -428,7 +428,6 @@ const benchmarkModel: BenchmarkModel = async (
         model = model(tf);
         log('3: ran model');
       }
-      log(model.customLayers)
       const upscalerOpts = {
         model: {
           ...model,

--- a/scripts/package-scripts/create-new-model-folder.ts
+++ b/scripts/package-scripts/create-new-model-folder.ts
@@ -188,7 +188,6 @@ type Size = 'rdn' | 'rrdn';
 const getModelDefinition = (scale: 2 | 3 | 4 | 8, architecture: Size, modelPath: string, meta = {}): ModelDefinitionFn => tf => {
   let preprocess: ModelDefinition['preprocess'];
   let postprocess: ModelDefinition['postprocess'] = clipOutput(tf);
-  let customLayers: ModelDefinition['customLayers'];
   if (architecture === 'rrdn') {
     const Layer = tf.layers.Layer;
     const BETA = 0.2;
@@ -238,7 +237,11 @@ const getModelDefinition = (scale: 2 | 3 | 4 | 8, architecture: Size, modelPath:
 
       static className = 'PixelShuffle';
     }
-    customLayers = [MultiplyBeta, PixelShuffle,];
+
+    [MultiplyBeta, PixelShuffle,].forEach((layer) => {
+      tf.serialization.registerClass(layer);
+    });
+
     preprocess = (image: Tensor) => tf.mul(image, 1 / 255);
     postprocess = (output: Tensor) => tf.tidy(() => {
       const clippedValue = (output).clipByValue(0, 1);
@@ -258,7 +261,6 @@ const getModelDefinition = (scale: 2 | 3 | 4 | 8, architecture: Size, modelPath:
     meta,
     preprocess,
     postprocess,
-    customLayers,
   };
 };
 


### PR DESCRIPTION
Instead of registering custom layers and ops via UpscalerJS, model definitions should simply register them themselves as needed.