### PR TITLE
Adding standalone model integration tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "test:integration:browserstack": "pnpm --filter @upscalerjs/scripts test:integration:browserstack",
     "test:integration:browser": "pnpm --filter @upscalerjs/scripts test:integration:browser",
     "test:integration:node": "pnpm --filter @upscalerjs/scripts test:integration:node",
+    "test:model": "pnpm --filter @upscalerjs/scripts test:model",
     "test:memory-leaks": "pnpm --filter @upscalerjs/scripts test:memory-leaks",
     "test:unit": "pnpm --filter upscaler test:unit",
     "test:unit:browser:playwright": "pnpm --filter upscaler test:unit:browser:playwright",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -21,6 +21,7 @@
     "test:integration:browser": "pnpm __run_command ./test.ts --platform browser",
     "test:integration:node": "pnpm __run_command ./test.ts --platform node",
     "test:memory-leaks": "pnpm __run_command ./test.ts --memoryTest --platform browser",
+    "test:model": "pnpm __run_command ./test.ts --kind model",
     "update:version": "pnpm __run_command ./package-scripts/update-version.ts",
     "update:tfjs": "pnpm __run_command ./package-scripts/update-tfjs.ts",
     "update:dependency": "pnpm __run_command ./package-scripts/update-dependency.ts",

--- a/test/integration/browser/model.ts
+++ b/test/integration/browser/model.ts
@@ -3,16 +3,13 @@
  */
 import { checkImage } from '../../lib/utils/checkImage';
 import { ESBUILD_DIST as ESBUILD_DIST, mockCDN as esbuildMockCDN } from '../../lib/esm-esbuild/prepare';
-import { DIST as UMD_DIST, mockCDN as umdMockCDN } from '../../lib/umd/prepare';
 import Upscaler, { ModelDefinition } from 'upscaler';
 import * as tf from '@tensorflow/tfjs';
 import type { Tensor3D, } from '@tensorflow/tfjs';
 import * as tfn from '@tensorflow/tfjs-node';
-import { AvailableModel, getFilteredModels } from '../../../scripts/package-scripts/utils/getAllAvailableModels';
 import { BrowserTestRunner } from '../utils/BrowserTestRunner';
 import path from 'path';
-import { MODELS_DIR, TMP_DIR } from '../../../scripts/package-scripts/utils/constants';
-import { getPackageJSON } from '../../../scripts/package-scripts/utils/packages';
+import { MODELS_DIR } from '../../../scripts/package-scripts/utils/constants';
 
 const PIXEL_UPSAMPLER_DIR = path.resolve(MODELS_DIR, 'pixel-upsampler/test/__fixtures__');
 const DEFAULT_MODEL_DIR = path.resolve(MODELS_DIR, 'default-model/test/__fixtures__');
@@ -24,26 +21,6 @@ const USE_PNPM = `${process.env.USE_PNPM}` === '1';
 const JEST_TIMEOUT = 60 * 1000 * 5;
 jest.setTimeout(JEST_TIMEOUT); // 5 minute timeout
 jest.retryTimes(0);
-
-const MODELS_TO_TEST = getFilteredModels({
-  specificPackage: undefined, 
-  specificModel: undefined,
-  filter: (packageName, model) => {
-    const packagePath = path.resolve(MODELS_DIR, packageName);
-    const packageJSON = getPackageJSON(packagePath);
-    const supportedPlatforms = packageJSON['@upscalerjs']?.models?.[model.export]?.supportedPlatforms;
-
-    return supportedPlatforms === undefined || supportedPlatforms.includes('browser');
-  },
-}).reduce((arr, [packageName, models]) => {
-  return arr.concat(models.map(({ esm, ...model }) => {
-    return [
-      packageName, {
-        ...model,
-        esm: esm === '' ? 'index' : esm,
-      }];
-  }));
-}, [] as [string, AvailableModel][]);
 
 describe('Model Loading Integration Tests', () => {
   const testRunner = new BrowserTestRunner({
@@ -143,80 +120,6 @@ describe('Model Loading Integration Tests', () => {
     const predictedTensor = tfn.tensor(predictedPixels).reshape([4,4,3]);
     const expectedTensor = tfn.image.resizeNearestNeighbor(tfn.tensor(startingPixels).reshape([2,2,3]).clipByValue(0, 255) as Tensor3D, [4,4]);
     expect(expectedTensor.dataSync()).toEqual(predictedTensor.dataSync())
-  });
-
-  describe('Test specific model implementations', () => {
-    describe('esm', () => {
-      MODELS_TO_TEST.map(([ packageName, { esm: esmName } ]) => {
-        it(`upscales with ${packageName}/${esmName} as esm`, async () => {
-          await testRunner.navigateToServer('| Loaded');
-          const result = await page().evaluate(([packageName, modelName]) => {
-            if (!modelName) {
-              throw new Error(`No model name found for package ${packageName}`);
-            }
-            // TODO: window fails to be typed correctly in CI
-            // https://github.com/thekevinscott/UpscalerJS/runs/7176553596?check_suite_focus=true#step:7:60
-            // Locally it works fine
-            const modelDefinition = (window as any)[packageName][modelName];
-            if (!modelDefinition) {
-              throw new Error(`No model definition found for package name ${packageName} and model name ${modelName}`);
-            }
-            const upscaler = new window['Upscaler']({
-              model: modelDefinition,
-            });
-            return upscaler.execute(window['fixtures'][packageName]);
-          }, [packageName, esmName]);
-          const resultPath = path.resolve(MODELS_DIR, packageName, "test/__fixtures__", esmName, "result.png")
-          const outputsPath = path.resolve(TMP_DIR, 'test-output/diff/browser/umd', packageName, esmName);
-          const diffPath = path.resolve(outputsPath, `diff.png`);
-          const upscaledPath = path.resolve(outputsPath, `upscaled.png`);
-          checkImage(result, resultPath, diffPath, upscaledPath);
-        });
-      });
-    });
-
-    describe('umd', () => {
-      const UMD_PORT = 8096;
-      const umdTestRunner = new BrowserTestRunner({
-        name: 'umd',
-        mockCDN: umdMockCDN,
-        dist: UMD_DIST,
-        port: UMD_PORT,
-      });
-
-      beforeAll(async function modelBeforeAll() {
-        await umdTestRunner.beforeAll();
-      }, 20000);
-
-      afterAll(async function modelAfterAll() {
-        await umdTestRunner.afterAll();
-      }, 30000);
-
-      beforeEach(async function beforeEach() {
-        await umdTestRunner.beforeEach(null);
-      });
-
-      afterEach(async function afterEach() {
-        await umdTestRunner.afterEach();
-      });
-
-      MODELS_TO_TEST.map(([ packageName, { esm: esmName, umd: umdName }]) => {
-        it(`upscales with ${packageName}/${esmName} as umd`, async () => {
-          const result = await umdTestRunner.page.evaluate(([umdName, packageName]) => {
-            const model: ModelDefinition = (<any>window)[umdName];
-            const upscaler = new window['Upscaler']({
-              model,
-            });
-            return upscaler.execute(window['fixtures'][packageName]);
-          }, [umdName, packageName]);
-          const resultPath = path.resolve(MODELS_DIR, packageName, "test/__fixtures__", esmName, "result.png")
-          const outputsPath = path.resolve(TMP_DIR, 'test-output/diff/browser/esm', packageName, esmName);
-          const diffPath = path.resolve(outputsPath, `diff.png`);
-          const upscaledPath = path.resolve(outputsPath, `upscaled.png`);
-          checkImage(result, resultPath, diffPath, upscaledPath);
-        });
-      });
-    });
   });
 
 });

--- a/test/integration/model.dependencies.ts
+++ b/test/integration/model.dependencies.ts
@@ -1,0 +1,13 @@
+import { bundleEsbuild } from "../lib/esm-esbuild/prepare";
+import { prepareScriptBundleForNodeCJS } from "../lib/node/prepare";
+import { prepareScriptBundleForUMD } from "../lib/umd/prepare";
+
+const dependencies = {
+  model: [
+    bundleEsbuild,
+    prepareScriptBundleForNodeCJS,
+    prepareScriptBundleForUMD,
+  ],
+};
+
+export default dependencies;

--- a/test/integration/model/model.ts
+++ b/test/integration/model/model.ts
@@ -77,7 +77,7 @@ if (PLATFORMS?.includes('browser')) {
 
     describe('esm', () => {
       MODELS_TO_TEST.map(([packageName, { esm: esmName }]) => {
-        it(`upscales with ${packageName}/${esmName} as esm`, async () => {
+        it(`${packageName}/${esmName}`, async () => {
           await testRunner.navigateToServer('| Loaded');
           const result = await page().evaluate(([packageName, modelName]) => {
             if (!modelName) {
@@ -130,7 +130,7 @@ if (PLATFORMS?.includes('browser')) {
       });
 
       MODELS_TO_TEST.map(([packageName, { esm: esmName, umd: umdName }]) => {
-        it(`upscales with ${packageName}/${esmName} as umd`, async () => {
+        it(`${packageName}/${esmName}`, async () => {
           const result = await umdTestRunner.page.evaluate(([umdName, packageName]) => {
             const model: ModelDefinition = (<any>window)[umdName];
             const upscaler = new window['Upscaler']({
@@ -208,7 +208,7 @@ if (PLATFORMS?.includes('node')) {
       describe(packageName, () => {
         filteredModels.forEach(({ cjs }) => {
           const cjsName = cjs || 'index';
-          it(`upscales with ${packageName}/${cjsName} as cjs`, async () => {
+          it(`${packageName}/${cjsName}`, async () => {
             const importPath = path.join(LOCAL_UPSCALER_NAMESPACE, packageName, cjsName === 'index' ? '' : `/${cjsName}`);
             const modelPackageDir = path.resolve(MODELS_DIR, packageName, 'test/__fixtures__');
             const fixturePath = path.resolve(modelPackageDir, 'fixture.png');

--- a/test/integration/model/model.ts
+++ b/test/integration/model/model.ts
@@ -1,0 +1,246 @@
+/****
+ * Tests that different approaches to loading a model all load correctly
+ */
+import { checkImage } from '../../lib/utils/checkImage';
+import { ESBUILD_DIST as ESBUILD_DIST, mockCDN as esbuildMockCDN } from '../../lib/esm-esbuild/prepare';
+import { DIST as UMD_DIST, mockCDN as umdMockCDN } from '../../lib/umd/prepare';
+import Upscaler, { ModelDefinition } from 'upscaler';
+import * as tf from '@tensorflow/tfjs';
+import { AvailableModel, getFilteredModels } from '../../../scripts/package-scripts/utils/getAllAvailableModels';
+import { BrowserTestRunner } from '../utils/BrowserTestRunner';
+import path from 'path';
+import { MODELS_DIR, TMP_DIR } from '../../../scripts/package-scripts/utils/constants';
+import { getPackageJSON } from '../../../scripts/package-scripts/utils/packages';
+import { LOCAL_UPSCALER_NAME, LOCAL_UPSCALER_NAMESPACE } from '../../lib/node/constants';
+import { Main, NodeTestRunner } from '../utils/NodeTestRunner';
+
+const TRACK_TIME = false;
+const LOG = true;
+const VERBOSE = false;
+const USE_PNPM = `${process.env.USE_PNPM}` === '1';
+const USE_GPU = process.env.useGPU === 'true';
+const PLATFORMS = process.env.platform?.split(',');
+
+const JEST_TIMEOUT = 60 * 1000 * 5;
+jest.setTimeout(JEST_TIMEOUT); // 5 minute timeout
+jest.retryTimes(0);
+
+
+if (PLATFORMS?.includes('browser')) {
+  const MODELS_TO_TEST = getFilteredModels({
+    specificPackage: undefined,
+    specificModel: undefined,
+    filter: (packageName, model) => {
+      const packagePath = path.resolve(MODELS_DIR, packageName);
+      const packageJSON = getPackageJSON(packagePath);
+      const supportedPlatforms = packageJSON['@upscalerjs']?.models?.[model.export]?.supportedPlatforms;
+
+      return supportedPlatforms === undefined || supportedPlatforms.includes('browser');
+    },
+  }).reduce((arr, [packageName, models]) => {
+    return arr.concat(models.map(({ esm, ...model }) => {
+      return [
+        packageName, {
+          ...model,
+          esm: esm === '' ? 'index' : esm,
+        }];
+    }));
+  }, [] as [string, AvailableModel][]);
+
+  describe('Browser Model Loading Integration Tests', () => {
+    const testRunner = new BrowserTestRunner({
+      name: 'esm',
+      mockCDN: esbuildMockCDN,
+      dist: ESBUILD_DIST,
+      trackTime: TRACK_TIME,
+      log: LOG,
+      verbose: VERBOSE,
+      usePNPM: USE_PNPM,
+    });
+    const page = () => testRunner.page;
+
+    beforeAll(async function beforeAll() {
+      await testRunner.beforeAll();
+    }, 60000);
+
+    afterAll(async function modelAfterAll() {
+      await testRunner.afterAll();
+    }, 10000);
+
+    beforeEach(async function beforeEach() {
+      await testRunner.beforeEach('| Loaded');
+    });
+
+    afterEach(async function afterEach() {
+      await testRunner.afterEach();
+    });
+
+    describe('esm', () => {
+      MODELS_TO_TEST.map(([packageName, { esm: esmName }]) => {
+        it(`upscales with ${packageName}/${esmName} as esm`, async () => {
+          await testRunner.navigateToServer('| Loaded');
+          const result = await page().evaluate(([packageName, modelName]) => {
+            if (!modelName) {
+              throw new Error(`No model name found for package ${packageName}`);
+            }
+            // TODO: window fails to be typed correctly in CI
+            // https://github.com/thekevinscott/UpscalerJS/runs/7176553596?check_suite_focus=true#step:7:60
+            // Locally it works fine
+            const modelDefinition = (window as any)[packageName][modelName];
+            if (!modelDefinition) {
+              throw new Error(`No model definition found for package name ${packageName} and model name ${modelName}`);
+            }
+            const upscaler = new window['Upscaler']({
+              model: modelDefinition,
+            });
+            return upscaler.execute(window['fixtures'][packageName]);
+          }, [packageName, esmName]);
+          const resultPath = path.resolve(MODELS_DIR, packageName, "test/__fixtures__", esmName, "result.png")
+          const outputsPath = path.resolve(TMP_DIR, 'test-output/diff/browser/umd', packageName, esmName);
+          const diffPath = path.resolve(outputsPath, `diff.png`);
+          const upscaledPath = path.resolve(outputsPath, `upscaled.png`);
+          checkImage(result, resultPath, diffPath, upscaledPath);
+        });
+      });
+    });
+
+    describe('umd', () => {
+      const UMD_PORT = 8096;
+      const umdTestRunner = new BrowserTestRunner({
+        name: 'umd',
+        mockCDN: umdMockCDN,
+        dist: UMD_DIST,
+        port: UMD_PORT,
+      });
+
+      beforeAll(async function modelBeforeAll() {
+        await umdTestRunner.beforeAll();
+      }, 20000);
+
+      afterAll(async function modelAfterAll() {
+        await umdTestRunner.afterAll();
+      }, 30000);
+
+      beforeEach(async function beforeEach() {
+        await umdTestRunner.beforeEach(null);
+      });
+
+      afterEach(async function afterEach() {
+        await umdTestRunner.afterEach();
+      });
+
+      MODELS_TO_TEST.map(([packageName, { esm: esmName, umd: umdName }]) => {
+        it(`upscales with ${packageName}/${esmName} as umd`, async () => {
+          const result = await umdTestRunner.page.evaluate(([umdName, packageName]) => {
+            const model: ModelDefinition = (<any>window)[umdName];
+            const upscaler = new window['Upscaler']({
+              model,
+            });
+            return upscaler.execute(window['fixtures'][packageName]);
+          }, [umdName, packageName]);
+          const resultPath = path.resolve(MODELS_DIR, packageName, "test/__fixtures__", esmName, "result.png")
+          const outputsPath = path.resolve(TMP_DIR, 'test-output/diff/browser/esm', packageName, esmName);
+          const diffPath = path.resolve(outputsPath, `diff.png`);
+          const upscaledPath = path.resolve(outputsPath, `upscaled.png`);
+          checkImage(result, resultPath, diffPath, upscaledPath);
+        });
+      });
+    });
+
+  });
+}
+
+if (PLATFORMS?.includes('node')) {
+  const main: Main = async (deps) => {
+    const {
+      Upscaler,
+      tf,
+      base64ArrayBuffer,
+      imagePath,
+      model,
+      fs,
+    } = deps;
+    console.log('Running main script with model', JSON.stringify(typeof model === 'function' ? model(tf) : model, null, 2));
+
+    const upscaler = new Upscaler({
+      model,
+    });
+
+    const imageData = fs.readFileSync(imagePath);
+    const tensor = tf.node.decodeImage(imageData).slice([0, 0, 0], [-1, -1, 3]); // discard alpha channel, if exists
+    const result = await upscaler.execute(tensor, {
+      output: 'tensor',
+      patchSize: 64,
+      padding: 6,
+      progress: console.log,
+    });
+    tensor.dispose();
+    // because we are requesting a tensor, it is possible that the tensor will
+    // contain out-of-bounds pixels; part of the value of this test is ensuring
+    // that those values are clipped in a post-process step.
+    const upscaledImage = await tf.node.encodePng(result);
+    result.dispose();
+    return base64ArrayBuffer(upscaledImage);
+  };
+
+  describe('Node Model Loading Integration Tests', () => {
+    const testRunner = new NodeTestRunner({
+      main,
+      trackTime: false,
+      dependencies: {
+        'tf': `@tensorflow/tfjs-node${USE_GPU ? '-gpu' : ''}`,
+        'Upscaler': `${LOCAL_UPSCALER_NAME}/node`,
+        'fs': 'fs',
+        'base64ArrayBuffer': path.resolve(__dirname, '../../lib/utils/base64ArrayBuffer'),
+      },
+    });
+
+    const filteredPackagesAndModels = getFilteredModels({
+      filter: (packageName, model) => {
+        const packagePath = path.resolve(MODELS_DIR, packageName);
+        const packageJSON = getPackageJSON(packagePath);
+        const supportedPlatforms = packageJSON['@upscalerjs']?.models?.[model.export]?.supportedPlatforms;
+
+        return supportedPlatforms === undefined || supportedPlatforms.includes('node');
+      },
+    });
+    filteredPackagesAndModels.forEach(([packageName, filteredModels]) => {
+      describe(packageName, () => {
+        filteredModels.forEach(({ cjs }) => {
+          const cjsName = cjs || 'index';
+          it(`upscales with ${packageName}/${cjsName} as cjs`, async () => {
+            const importPath = path.join(LOCAL_UPSCALER_NAMESPACE, packageName, cjsName === 'index' ? '' : `/${cjsName}`);
+            const modelPackageDir = path.resolve(MODELS_DIR, packageName, 'test/__fixtures__');
+            const fixturePath = path.resolve(modelPackageDir, 'fixture.png');
+            const result = await testRunner.run({
+              dependencies: {
+                customModel: importPath,
+              },
+              globals: {
+                model: 'customModel',
+                imagePath: JSON.stringify(fixturePath),
+              }
+            });
+
+            expect(result).not.toEqual('');
+            const formattedResult = `data:image/png;base64,${result}`;
+            const resultPath = path.resolve(MODELS_DIR, packageName, "test/__fixtures__", cjsName, "result.png")
+            const outputsPath = path.resolve(TMP_DIR, 'test-output/diff/node', packageName, cjsName);
+            const diffPath = path.resolve(outputsPath, `diff.png`);
+            const upscaledPath = path.resolve(outputsPath, `upscaled.png`);
+            checkImage(formattedResult, resultPath, diffPath, upscaledPath);
+          });
+        });
+      });
+    });
+  });
+}
+
+declare global {
+  interface Window {
+    Upscaler: typeof Upscaler;
+    tf: typeof tf;
+    fixtures: Record<string, string>;
+    PixelUpsampler2x: ModelDefinition;
+  }
+}

--- a/test/jestconfig.model.js
+++ b/test/jestconfig.model.js
@@ -1,0 +1,7 @@
+const jestconfig = require('./jestconfig.json');
+module.exports = {
+  ...jestconfig,
+  roots: [
+    "<rootDir>/integration/model",
+  ],
+};


### PR DESCRIPTION
No longer run model tests as part of normal CI, as that won't scale as we add more models.

For now, model tests can be run manually with:

`pnpm model:test`