### PR TITLE
Clean up script outputs and tmp directories

### DIFF
--- a/scripts/package-scripts/utils/withTmpDir.ts
+++ b/scripts/package-scripts/utils/withTmpDir.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import rimraf from 'rimraf';
-import fs from 'fs';
-import { mkdirpSync } from 'fs-extra';
+import { existsSync, mkdirpSync } from 'fs-extra';
 import { getHashedName } from './getHashedName';
 import { TMP_DIR } from './constants';
 
@@ -11,7 +10,7 @@ interface WithTmpDirOpts {
 }
 type WithTmpDir = (callback: WithTmpDirFn, opts?: WithTmpDirOpts) => (Promise<void> | void);
 type WithTmpDirFn = (tmp: string) => Promise<void>;
-export const withTmpDir: WithTmpDir = async (callback, { rootDir, removeTmpDir } = {}) => {
+export const withTmpDir: WithTmpDir = async (callback, { rootDir, removeTmpDir = true } = {}) => {
   const tmpDir = makeTmpDir(rootDir);
 
   try {
@@ -19,7 +18,7 @@ export const withTmpDir: WithTmpDir = async (callback, { rootDir, removeTmpDir }
   }
   finally {
     try {
-      if (tmpDir && removeTmpDir) {
+      if (removeTmpDir) {
         rimraf.sync(tmpDir);
       }
     }
@@ -30,9 +29,10 @@ export const withTmpDir: WithTmpDir = async (callback, { rootDir, removeTmpDir }
 };
 
 export const makeTmpDir = (root = TMP_DIR): string => {
-  const folder = path.resolve(root, getHashedName(`${Math.random()}`));
+  const hashedName = getHashedName(`${Math.random()}`);
+  const folder = path.resolve(root, hashedName);
   mkdirpSync(folder);
-  if (!fs.existsSync(folder)) {
+  if (!existsSync(folder)) {
     throw new Error(`Tmp directory ${folder} was not created`);
   }
   return folder;

--- a/scripts/test.ts
+++ b/scripts/test.ts
@@ -215,7 +215,7 @@ const test = async (platform: Platform | Platform[], runner: Runner, kind: Kind,
       watch ? '--watch' : undefined,
       ...positionalArgs,
     ].filter(Boolean).map(arg => `${arg}`);
-    console.log('args', args);
+    // console.log('args', args);
 
     const code = await runTTYProcess(args[0], args.slice(1), { verbose, platform, useGPU });
     if (bsLocal !== undefined) {

--- a/test/integration/node/image.ts
+++ b/test/integration/node/image.ts
@@ -86,7 +86,7 @@ describe('Node Image Loading Integration Tests', () => {
       checkImage(`data:image/png;base64,${result}`, EXPECTED_UPSCALED_IMAGE_15, DIFF_IMAGE_OUTPUT);
     });
 
-    it('throws if given 4-channel Uint8Array', async () => {
+    it.only('throws if given 4-channel Uint8Array', async () => {
       const mockedTensor = tf.node.decodeImage(fs.readFileSync(FOUR_CHANNEL_FIXTURE_PATH));
       await expect(() => testRunner.run({
         globals: {

--- a/test/lib/utils/callExec.ts
+++ b/test/lib/utils/callExec.ts
@@ -1,15 +1,15 @@
 import { exec, ExecOptions } from 'child_process';
 
-type StdOut = (chunk: string) => void;
-type StdErr = (chunk: string) => void;
+export type StdOut = (chunk: string) => void;
+export type StdErr = (chunk: string) => void;
 
-const callExec = (cmd: string, {
+export const callExec = (cmd: string, {
   verbose = false,
   ...options
 }: {
   encoding?: 'buffer' | null;
   verbose?: boolean;
-} & ExecOptions = {}, stdout?: StdOut | boolean, stderr: StdErr | boolean = true): Promise<void> => new Promise((resolve, reject) => {
+} & ExecOptions = {}, stdout?: StdOut | boolean, stderr?: StdErr | boolean): Promise<void> => new Promise((resolve, reject) => {
   if (verbose) {
     console.log(`Running command: ${cmd}`);
   }


### PR DESCRIPTION
- Hide stderr by default unless verbose mode is on.
- Nested tmp dirs in Node integration test scripts are now deleted after test runs