### PR TITLE
Pin TFJS to 4.8.0

### DIFF
--- a/dev/browser/generate-pixel-upsampler-model/index.html
+++ b/dev/browser/generate-pixel-upsampler-model/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>UpscalerJS Development: Generate Pixel Upsampler Model</title>
+  <link rel="stylesheet" href="../global.css" />
+  <link rel="stylesheet" href="index.scss" />
+</head>
+<body>
+  <div id="container">
+    <h1>Generate Pixel Upsampler Model</h1>
+    <form>
+      <button type="submit">Generate</button>
+    </form>
+    <pre id="output"></pre>
+    <div id="images">
+      <h2>Images</h2>
+      <div class="image">
+        <h3>Fixture</h3>
+        <img id="fixture" src="/node_modules/@upscalerjs/pixel-upsampler/assets/fixture.png" width="16" />
+      </div>
+    </div>
+  </div>
+  <script type="module" src="./index.ts"></script>
+</body>
+</html>

--- a/dev/browser/generate-pixel-upsampler-model/index.scss
+++ b/dev/browser/generate-pixel-upsampler-model/index.scss
@@ -1,0 +1,37 @@
+* {
+  box-sizing: border-box;
+}
+
+#container {
+  padding: 40px;
+  width: 600px;
+}
+
+pre {
+  min-height: 100px;
+  background: rgba(0,0,0,0.8);
+  color: white;
+}
+
+h3 {
+  margin: 0 0 10px 0;
+}
+
+.image {
+  border: 1px solid rgba(0,0,0,0.1);
+  padding: 20px;
+  margin-bottom: 10px;
+}
+
+form {
+  button {
+    padding: 20px;
+    width: 100%;
+  }
+
+  section {
+    border: 1px solid rgba(0,0,0,0.1);
+    padding: 20px;
+    margin: 0 0 20px 0;
+  }
+}

--- a/dev/browser/generate-pixel-upsampler-model/index.ts
+++ b/dev/browser/generate-pixel-upsampler-model/index.ts
@@ -1,0 +1,64 @@
+import * as tf from '@tensorflow/tfjs';
+const imagesContainer = document.getElementById('images');
+const output = document.getElementById('output');
+
+const makeModel = (scale: number) => {
+  const model = tf.sequential();
+  model.add(tf.layers.upSampling2d({
+    size: [scale, scale],
+    dataFormat: 'channelsLast',
+    inputShape: [null, null, 3],
+  }));
+  // model.add(tf.layers.dense({units: 1, inputShape: [1]}));
+
+  model.compile({ loss: "meanSquaredError", optimizer: "sgd" });
+  return model;
+}
+
+const isTensorList = (t: tf.Tensor | tf.Tensor[]): t is tf.Tensor[] => {
+  return Array.isArray(t);
+}
+
+function predict(model, x) {
+  let prediction = model.predict(x.expandDims(0));
+  if (isTensorList(prediction)) {
+    prediction = prediction[0];
+  }
+  return prediction.squeeze() as tf.Tensor3D;
+}
+
+const draw = async (t: tf.Tensor3D, scale: number) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = t.size[1] * scale;
+  canvas.height = t.size[0] * scale;
+  const imageContainer = document.createElement('div');
+  const h3 = document.createElement('h3');
+  h3.innerHTML = `${scale}x`;
+  imageContainer.className = 'image';
+  imageContainer.appendChild(h3);
+  imageContainer.appendChild(canvas);
+  imagesContainer.appendChild(imageContainer);
+  const resized = tf.image.resizeBilinear(t, [t.shape[0] * scale, t.shape[1] * scale]);
+  await tf.browser.toPixels(resized, canvas);
+  resized.dispose();
+}
+
+const generatePixelUpsampler = async () => {
+  output.innerHTML = 'Generating pixel upsampler...';
+  for (const scale of [2, 3, 4]) {
+    const model = await makeModel(scale);
+    output.innerHTML += `\nCreated pixel upsampler for scale ${scale}`;
+    tf.tidy(() => {
+      const input = tf.browser.fromPixels(document.getElementById('fixture') as HTMLImageElement);
+      const prediction = predict(model, input);
+      draw(prediction.div(255), scale);
+    });
+    model.save(`downloads://${scale}x`);
+  }
+};
+
+const form = document.getElementsByTagName('form')[0] as HTMLFormElement;
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  generatePixelUpsampler();
+});

--- a/dev/browser/index.html
+++ b/dev/browser/index.html
@@ -11,6 +11,7 @@
     <li><a href="/web-worker/">Web Workers test</a></li>
     <li><a href="/exploring-tfjs-ops/">Exploring TFJS Ops</a></li>
     <li><a href="/exploring-layers-and-graph-models/">Exploring Layers and Graph Models</a></li>
+    <li><a href="/generate-pixel-upsampler-model/">Generate Pixel Upsampler Model</a></li>
   </ul>
 </body>
 </html>

--- a/dev/browser/package.json
+++ b/dev/browser/package.json
@@ -10,12 +10,13 @@
     "@upscalerjs/esrgan-slim": "workspace:*",
     "@upscalerjs/esrgan-medium": "workspace:*",
     "@upscalerjs/esrgan-legacy": "workspace:*",
+    "@upscalerjs/pixel-upsampler": "workspace:*",
     "seedrandom": "3.0.5",
     "@types/stats.js": "^0.17.0",
     "vite": "^3.1.5"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "stats.js": "^0.17.0"
   },
   "version": "1.0.0-beta.10"

--- a/dev/node/package.json
+++ b/dev/node/package.json
@@ -6,7 +6,7 @@
     "dev": "ts-node src/index.ts"
   },
   "dependencies": {
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "commander": "^10.0.1",
     "seedrandom": "3.0.5",
     "ts-node": "^10.9.1",

--- a/docs/package.json
+++ b/docs/package.json
@@ -31,7 +31,7 @@
     "@docusaurus/theme-common": "^2.4.1",
     "@mdx-js/react": "^1.6.22",
     "@shoelace-style/shoelace": "2.0.0-beta.80",
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-medium": "workspace:*",
     "chart.js": "^4.3.0",
     "classnames": "^2.3.2",

--- a/docs/src/components/homepage/homepage-code-embed/package.json
+++ b/docs/src/components/homepage/homepage-code-embed/package.json
@@ -9,7 +9,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "@upscalerjs/esrgan-thick": "latest",
     "upscaler": "latest"

--- a/docs/workers/upscale/package.json
+++ b/docs/workers/upscale/package.json
@@ -19,7 +19,7 @@
     "deploy:prod": "wrangler publish -e production"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "aws-sdk": "^2.1193.0",
     "jpeg-js": "^0.4.4",
     "mock-aws-s3": "^4.0.2",

--- a/examples/basic-npm/package.json
+++ b/examples/basic-npm/package.json
@@ -17,7 +17,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/cancel/package.json
+++ b/examples/cancel/package.json
@@ -10,7 +10,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -15,8 +15,8 @@
     "wrangler:start": "npx wrangler dev"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-core": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
     "@upscalerjs/esrgan-slim": "^1.0.0-beta.7",
     "@upscalerjs/esrgan-thick": "^1.0.0-beta.10",
     "aws-sdk": "^2.1414.0",

--- a/examples/memory-management/package.json
+++ b/examples/memory-management/package.json
@@ -10,7 +10,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/models/package.json
+++ b/examples/models/package.json
@@ -10,7 +10,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-thick": "1.0.0-beta.8",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"

--- a/examples/nodejs-custom-models/package.json
+++ b/examples/nodejs-custom-models/package.json
@@ -13,7 +13,7 @@
     "node": "^16.0.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-node": "^4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
     "express": "4.18.2",
     "seedrandom": "3.0.5",
     "upscaler": "1.0.0-beta.14"

--- a/examples/nodejs-model/package.json
+++ b/examples/nodejs-model/package.json
@@ -10,8 +10,8 @@
     "dev": "node src/index.js localhost 8080"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
     "@upscalerjs/esrgan-thick": "1.0.0-beta.11",
     "express": "4.18.2",
     "seedrandom": "3.0.5",

--- a/examples/nodejs/package.json
+++ b/examples/nodejs/package.json
@@ -13,7 +13,7 @@
     "node": "^16.0.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-node": "^4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
     "express": "4.16.4",
     "seedrandom": "3.0.5",
     "upscaler": "1.0.0-beta.14"

--- a/examples/patch-sizes/package.json
+++ b/examples/patch-sizes/package.json
@@ -13,7 +13,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/progress/package.json
+++ b/examples/progress/package.json
@@ -13,7 +13,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@babel/plugin-syntax-flow": "^7.22.5",
     "@babel/plugin-transform-react-jsx": "^7.22.5",
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-dropzone": "^11.7.1",

--- a/examples/self-hosting-models/package.json
+++ b/examples/self-hosting-models/package.json
@@ -10,7 +10,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/tensors/package.json
+++ b/examples/tensors/package.json
@@ -10,7 +10,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/upload/package.json
+++ b/examples/upload/package.json
@@ -13,7 +13,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/warmup/package.json
+++ b/examples/warmup/package.json
@@ -13,7 +13,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/webcam/package.json
+++ b/examples/webcam/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/examples/webworker/package.json
+++ b/examples/webworker/package.json
@@ -13,7 +13,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.14"
   },

--- a/models/default-model/demo/package.json
+++ b/models/default-model/demo/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/default-model": "1.0.0-beta.7",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.8"

--- a/models/default-model/package.json
+++ b/models/default-model/package.json
@@ -35,17 +35,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "@upscalerjs": {

--- a/models/esrgan-experiments/package.json
+++ b/models/esrgan-experiments/package.json
@@ -4239,17 +4239,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "@upscalerjs": {

--- a/models/esrgan-legacy/demo/package.json
+++ b/models/esrgan-legacy/demo/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-legacy": "1.0.0-beta.9",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.8"

--- a/models/esrgan-legacy/package.json
+++ b/models/esrgan-legacy/package.json
@@ -55,17 +55,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "author": "Kevin Scott",

--- a/models/esrgan-medium/demo/package.json
+++ b/models/esrgan-medium/demo/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-medium": "1.0.0-beta.7",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.8"

--- a/models/esrgan-medium/package.json
+++ b/models/esrgan-medium/package.json
@@ -51,17 +51,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "author": "Kevin Scott",

--- a/models/esrgan-slim/demo/package.json
+++ b/models/esrgan-slim/demo/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-slim": "1.0.0-beta.7",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.8"

--- a/models/esrgan-slim/package.json
+++ b/models/esrgan-slim/package.json
@@ -51,17 +51,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "author": "Kevin Scott",

--- a/models/esrgan-thick/demo/package.json
+++ b/models/esrgan-thick/demo/package.json
@@ -12,7 +12,7 @@
   "author": "Kevin Scott",
   "license": "MIT",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
     "@upscalerjs/esrgan-thick": "1.0.0-beta.7",
     "seedrandom": "^3.0.5",
     "upscaler": "1.0.0-beta.8"

--- a/models/esrgan-thick/package.json
+++ b/models/esrgan-thick/package.json
@@ -51,17 +51,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "repository": {

--- a/models/pixel-upsampler/package.json
+++ b/models/pixel-upsampler/package.json
@@ -35,17 +35,17 @@
     "dist/**/*"
   ],
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0",
-    "@tensorflow/tfjs-layers": "^4.8.0",
+    "@tensorflow/tfjs-core": "~4.8.0",
+    "@tensorflow/tfjs-layers": "~4.8.0",
     "@upscalerjs/core": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "seedrandom": "3.0.5"
   },
   "author": "Kevin Scott",

--- a/package.json
+++ b/package.json
@@ -68,9 +68,9 @@
   "license": "MIT",
   "homepage": "https://github.com/thekevinscott/UpscalerJS",
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.22.9",
@@ -82,9 +82,9 @@
     "@rollup/plugin-commonjs": "^22.0.2",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@schemastore/package": "^0.0.6",
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "@types/babel__core": "^7.20.1",
     "@types/chai": "^4.3.5",
     "@types/chai-as-promised": "^7.1.5",
@@ -152,9 +152,9 @@
   },
   "pnpm": {
     "overrides": {
-      "@tensorflow/tfjs": "^4.8.0",
-      "@tensorflow/tfjs-node": "^4.8.0",
-      "@tensorflow/tfjs-node-gpu": "^4.8.0"
+      "@tensorflow/tfjs": "~4.8.0",
+      "@tensorflow/tfjs-node": "~4.8.0",
+      "@tensorflow/tfjs-node-gpu": "~4.8.0"
     }
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
     "build:cjs": "pnpm --filter @upscalerjs/scripts build:core node -o cjs"
   },
   "dependencies": {
-    "@tensorflow/tfjs-core": "^4.8.0"
+    "@tensorflow/tfjs-core": "~4.8.0"
   },
   "devDependencies": {
     "@types/jest": "^29.0.3"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "@upscalerjs/core": "workspace:*",
-    "@tensorflow/tfjs-core": "^4.8.0"
+    "@tensorflow/tfjs-core": "~4.8.0"
   }
 }

--- a/packages/upscalerjs/package.json
+++ b/packages/upscalerjs/package.json
@@ -77,16 +77,16 @@
   },
   "homepage": "https://github.com/thekevinscott/UpscalerJS#readme",
   "peerDependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "dependencies": {
     "@upscalerjs/core": "workspace:*",
     "@upscalerjs/default-model": "workspace:*"
   },
   "devDependencies": {
-    "@tensorflow/tfjs": "^4.8.0",
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs": "~4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "@types/jest": "^29.0.3",
     "chokidar": "^3.5.3",
     "seedrandom": "3.0.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  '@tensorflow/tfjs': ^4.8.0
-  '@tensorflow/tfjs-node': ^4.8.0
-  '@tensorflow/tfjs-node-gpu': ^4.8.0
+  '@tensorflow/tfjs': ~4.8.0
+  '@tensorflow/tfjs-node': ~4.8.0
+  '@tensorflow/tfjs-node-gpu': ~4.8.0
 
 importers:
 
@@ -41,13 +41,13 @@ importers:
         specifier: ^0.0.6
         version: 0.0.6
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@types/babel__core':
         specifier: ^7.20.1
@@ -245,7 +245,7 @@ importers:
   dev/browser:
     dependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       stats.js:
         specifier: ^0.17.0
@@ -266,6 +266,9 @@ importers:
       '@upscalerjs/esrgan-thick':
         specifier: workspace:*
         version: link:../../models/esrgan-thick
+      '@upscalerjs/pixel-upsampler':
+        specifier: workspace:*
+        version: link:../../models/pixel-upsampler
       seedrandom:
         specifier: 3.0.5
         version: 3.0.5
@@ -279,7 +282,7 @@ importers:
   dev/node:
     dependencies:
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       commander:
         specifier: ^10.0.1
@@ -312,7 +315,7 @@ importers:
         specifier: 2.0.0-beta.80
         version: 2.0.0-beta.80
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@upscalerjs/esrgan-medium':
         specifier: workspace:*
@@ -448,17 +451,17 @@ importers:
   docs/src/components/homepage/homepage-code-embed:
     dependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@upscalerjs/esrgan-thick':
         specifier: latest
-        version: 1.0.0-beta.11(@tensorflow/tfjs@4.8.0)
+        version: link:../../../../../models/esrgan-thick
       seedrandom:
         specifier: ^3.0.5
         version: 3.0.5
       upscaler:
         specifier: latest
-        version: 1.0.0-beta.16(@tensorflow/tfjs@4.8.0)
+        version: link:../../../../../packages/upscalerjs
 
   docs/workers/image-search:
     devDependencies:
@@ -490,7 +493,7 @@ importers:
   docs/workers/upscale:
     dependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       aws-sdk:
         specifier: ^2.1193.0
@@ -564,19 +567,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -589,19 +592,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -614,19 +617,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -639,19 +642,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -664,19 +667,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -689,19 +692,19 @@ importers:
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -710,23 +713,23 @@ importers:
   models/pixel-upsampler:
     dependencies:
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@tensorflow/tfjs-layers':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(@tensorflow/tfjs-core@4.8.0)
       '@upscalerjs/core':
         specifier: workspace:*
         version: link:../../packages/core
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       seedrandom:
         specifier: 3.0.5
@@ -735,7 +738,7 @@ importers:
   packages/core:
     dependencies:
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
     devDependencies:
       '@types/jest':
@@ -745,7 +748,7 @@ importers:
   packages/shared:
     dependencies:
       '@tensorflow/tfjs-core':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0
       '@upscalerjs/core':
         specifier: workspace:*
@@ -761,13 +764,13 @@ importers:
         version: link:../../models/default-model
     devDependencies:
       '@tensorflow/tfjs':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@tensorflow/tfjs-node-gpu':
-        specifier: ^4.8.0
+        specifier: ~4.8.0
         version: 4.8.0(seedrandom@3.0.5)
       '@types/jest':
         specifier: ^29.0.3
@@ -1158,7 +1161,7 @@ packages:
       '@babel/core': 7.22.9
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.1
-      semver: 6.3.0
+      semver: 6.3.1
 
   /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
     resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
@@ -1222,7 +1225,7 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.1
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -2213,7 +2216,7 @@ packages:
       babel-plugin-polyfill-corejs2: 0.3.2(@babel/core@7.22.9)
       babel-plugin-polyfill-corejs3: 0.5.3(@babel/core@7.22.9)
       babel-plugin-polyfill-regenerator: 0.4.0(@babel/core@7.22.9)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -4420,7 +4423,7 @@ packages:
       nopt: 5.0.0
       npmlog: 5.0.1
       rimraf: 3.0.2
-      semver: 7.3.8
+      semver: 7.5.4
       tar: 6.1.15
     transitivePeerDependencies:
       - encoding
@@ -4494,7 +4497,7 @@ packages:
     resolution: {integrity: sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==}
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.3.8
+      semver: 7.5.4
     dev: false
     optional: true
 
@@ -5602,28 +5605,6 @@ packages:
       - encoding
     dev: false
 
-  /@upscalerjs/default-model@1.0.0-beta.14(@tensorflow/tfjs@4.8.0):
-    resolution: {integrity: sha512-h7BiWOeSzAXNZcL5XTw5EGsQGcREBzxh8/UYUKHzdZfKd89OLuN0DG5nCWJsIe2aEL1XgrsNnDxUr9CmxC656A==}
-    peerDependencies:
-      '@tensorflow/tfjs': ^4.2.0
-    dependencies:
-      '@tensorflow/tfjs': 4.8.0(seedrandom@3.0.5)
-      '@upscalerjs/core': 1.0.0-beta.14
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@upscalerjs/esrgan-thick@1.0.0-beta.11(@tensorflow/tfjs@4.8.0):
-    resolution: {integrity: sha512-YY8EHpErjjQ/uyA7lw8oWW08wYYws7rXerIGgdfZ5X5TiPir8BcC5SWqOo7i12e3+ODBS47eY762jzHPiM1dvw==}
-    peerDependencies:
-      '@tensorflow/tfjs': ^4.2.0
-    dependencies:
-      '@tensorflow/tfjs': 4.8.0(seedrandom@3.0.5)
-      '@upscalerjs/core': 1.0.0-beta.14
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
   /@webassemblyjs/ast@1.11.6:
     resolution: {integrity: sha512-IN1xI7PwOvLPgjcf180gC1bqn3q/QaOCwYUahIOhbYUu8KA/3tw2RT/T0Gidi1l7Hhj5D/INhJxiICObqpMu4Q==}
     dependencies:
@@ -6213,7 +6194,7 @@ packages:
       '@babel/compat-data': 7.18.8
       '@babel/core': 7.22.9
       '@babel/helper-define-polyfill-provider': 0.3.2(@babel/core@7.22.9)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7483,7 +7464,7 @@ packages:
       postcss-modules-scope: 3.0.0(postcss@8.4.17)
       postcss-modules-values: 4.0.0(postcss@8.4.17)
       postcss-value-parser: 4.2.0
-      semver: 7.3.8
+      semver: 7.5.4
       webpack: 5.88.1(esbuild@0.11.23)(uglify-js@3.17.4)
 
   /css-minimizer-webpack-plugin@4.0.0(clean-css@5.3.0)(esbuild@0.11.23)(webpack@5.88.1):
@@ -9331,7 +9312,7 @@ packages:
       memfs: 3.4.4
       minimatch: 3.1.2
       schema-utils: 2.7.0
-      semver: 7.3.8
+      semver: 7.5.4
       tapable: 1.1.3
       typescript: 4.9.5
       webpack: 5.88.1(esbuild@0.11.23)(uglify-js@3.17.4)
@@ -10728,7 +10709,7 @@ packages:
       '@babel/parser': 7.20.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11720,7 +11701,7 @@ packages:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -12226,10 +12207,10 @@ packages:
 
   /minimist@1.2.6:
     resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+    dev: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /minipass-collect@1.0.2:
     resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
@@ -12316,7 +12297,7 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.8
 
   /mkdirp@1.0.4:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
@@ -12489,7 +12470,7 @@ packages:
     resolution: {integrity: sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==}
     engines: {node: '>=10'}
     dependencies:
-      semver: 7.3.8
+      semver: 7.5.4
     dev: true
 
   /node-addon-api@4.3.0:
@@ -12917,7 +12898,7 @@ packages:
       got: 9.6.0
       registry-auth-token: 4.2.2
       registry-url: 5.1.0
-      semver: 6.3.0
+      semver: 6.3.1
 
   /pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
@@ -13260,7 +13241,7 @@ packages:
       cosmiconfig: 7.0.1
       klona: 2.0.5
       postcss: 8.4.17
-      semver: 7.3.8
+      semver: 7.5.4
       webpack: 5.88.1(esbuild@0.11.23)(uglify-js@3.17.4)
 
   /postcss-merge-idents@5.1.1(postcss@8.4.17):
@@ -13889,7 +13870,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.6
+      minimist: 1.2.8
       strip-json-comments: 2.0.1
 
   /react-base16-styling@0.6.0:
@@ -14767,14 +14748,10 @@ packages:
     resolution: {integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
 
   /semver@5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
-    hasBin: true
-
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
 
   /semver@6.3.1:
@@ -14805,7 +14782,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /send@0.18.0:
     resolution: {integrity: sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==}
@@ -16421,7 +16397,7 @@ packages:
       is-yarn-global: 0.3.0
       latest-version: 5.1.0
       pupa: 2.1.1
-      semver: 7.3.8
+      semver: 7.5.4
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
 
@@ -16434,19 +16410,6 @@ packages:
       '@tensorflow/tfjs': 4.8.0(seedrandom@3.0.5)
       '@upscalerjs/core': 1.0.0-beta.14
       '@upscalerjs/default-model': 1.0.0-beta.12(@tensorflow/tfjs@4.8.0)
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /upscaler@1.0.0-beta.16(@tensorflow/tfjs@4.8.0):
-    resolution: {integrity: sha512-/ccCpszl4gRhNJaVdlALYcBu5+XfGUZbp4N7rjrCasJ2KUu6+vFT8NsclBc61rhrbJOQNv2IkthVGYLcE6BhJA==}
-    engines: {node: '>=16.0'}
-    peerDependencies:
-      '@tensorflow/tfjs': ^4.2.0
-    dependencies:
-      '@tensorflow/tfjs': 4.8.0(seedrandom@3.0.5)
-      '@upscalerjs/core': 1.0.0-beta.14
-      '@upscalerjs/default-model': 1.0.0-beta.14(@tensorflow/tfjs@4.8.0)
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -16727,7 +16690,7 @@ packages:
       axios: 0.25.0
       joi: 17.6.0
       lodash: 4.17.21
-      minimist: 1.2.6
+      minimist: 1.2.8
       rxjs: 7.5.5
     transitivePeerDependencies:
       - debug

--- a/test/integration/utils/NodeTestRunner.ts
+++ b/test/integration/utils/NodeTestRunner.ts
@@ -90,7 +90,7 @@ export class NodeTestRunner<T extends DefinedDependencies> {
     });
     let testName = '';
     try {
-      testName = expect.getState().currentTestName;
+      testName = expect.getState().currentTestName || '';
     } catch(err) {}
     try {
       let output: Buffer | undefined;

--- a/test/lib/esm-esbuild/package.json
+++ b/test/lib/esm-esbuild/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-beta.10",
   "main": "index.js",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.22.5",

--- a/test/lib/esm-webpack/package.json
+++ b/test/lib/esm-webpack/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.0-beta.10",
   "main": "index.js",
   "dependencies": {
-    "@tensorflow/tfjs": "^4.8.0"
+    "@tensorflow/tfjs": "~4.8.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^5.5.3",

--- a/test/lib/node/package.json
+++ b/test/lib/node/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "version": "1.0.0-beta.10",
   "dependencies": {
-    "@tensorflow/tfjs-node": "^4.8.0",
-    "@tensorflow/tfjs-node-gpu": "^4.8.0",
+    "@tensorflow/tfjs-node": "~4.8.0",
+    "@tensorflow/tfjs-node-gpu": "~4.8.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Pin TFJS to `4.8.0`. There's a bug introduced in `4.9.0` that breaks the pixel upsampler model (https://github.com/tensorflow/tfjs/issues/7865).

Also adds the ability to re-generate pixel upsampler model from scratch in the `/dev` folder. This will be helpful if future TFJS `save` methods introduce breaking changes.