### PR TITLE
Refactor package information to _internals

### DIFF
--- a/models/pixel-upsampler/src/getModelDefinition.ts
+++ b/models/pixel-upsampler/src/getModelDefinition.ts
@@ -5,9 +5,11 @@ const getModelDefinition = (scale: 2 | 3 | 4): ModelDefinition => ({
   scale,
   path: `models/${scale}x/${scale}x.json`,
   modelType: 'layers',
-  packageInformation: {
-    name: NAME,
-    version: VERSION,
+  _internals: {
+    packageInformation: {
+      name: NAME,
+      version: VERSION,
+    },
   },
   meta: {
     dataset: null,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,13 +40,13 @@ export const isDynamicShape4D = (shape?: unknown): shape is DynamicShape4D => is
 
 export interface ModelDefinition {
   /**
+   * The type of the model. Can be 'graph' or 'layer'.
+   */
+  modelType: ModelType;
+  /**
    * Path to a model.json file.
    */
   path: string;
-  /**
-   * The type of the model. Can be 'graph' or 'layer'. Defaults to 'layer'
-   */
-  modelType: ModelType;
   /**
    * The scale of the model. For super resolution models, should match the scale at which the model was trained.
    */
@@ -60,9 +60,11 @@ export interface ModelDefinition {
   /**
    * @hidden
    * 
-   * Used internally by UpscalerJS models to encode information about package version and name.
+   * Used internally by UpscalerJS models to encode information about the model configuration, such as package version, package name, and path to model JSON file.
    */
-  packageInformation?: PackageInformation;
+  _internals?: {
+    packageInformation?: PackageInformation;
+  };
   /**
    * A function that processes the input image before feeding to the model. For example, you can use this function if you need to regularize your input.
    */

--- a/packages/shared/src/esrgan/esrgan.ts
+++ b/packages/shared/src/esrgan/esrgan.ts
@@ -39,9 +39,11 @@ export const getESRGANModelDefinition = ({
       scale,
       path,
       modelType: 'layers',
-      packageInformation: {
-        name,
-        version,
+      _internals: {
+        packageInformation: {
+          name,
+          version,
+        },
       },
       meta: {
         architecture,
@@ -104,9 +106,11 @@ export const getESRGANModelDefinition = ({
     scale,
     path,
     modelType: 'layers',
-    packageInformation: {
-      name,
-      version,
+    _internals: {
+      packageInformation: {
+        name,
+        version,
+      },
     },
     meta: {
       architecture,

--- a/packages/upscalerjs/src/loadModel.browser.test.ts
+++ b/packages/upscalerjs/src/loadModel.browser.test.ts
@@ -112,9 +112,11 @@ describe('loadModel browser tests', () => {
         expect(loadTfModel).toBeCalledTimes(0);
         await fetchModel({
           path: modelPath,
-          packageInformation: {
-            name: packageName,
-            version,
+          _internals: {
+            packageInformation: {
+              name: packageName,
+              version,
+            },
           },
           modelType: 'layers',
         } as ModelDefinition);
@@ -129,9 +131,11 @@ describe('loadModel browser tests', () => {
         expect(loadTfModel).toBeCalledTimes(0);
         await fetchModel({
           path: modelPath,
-          packageInformation: {
-            name: packageName,
-            version,
+          _internals: {
+            packageInformation: {
+              name: packageName,
+              version,
+            },
           },
           modelType: 'graph',
         } as ModelDefinition);
@@ -152,9 +156,11 @@ describe('loadModel browser tests', () => {
         expect(loadTfModel).toBeCalledTimes(0);
         await fetchModel({
           path: modelPath,
-          packageInformation: {
-            name: packageName,
-            version,
+          _internals: {
+            packageInformation: {
+              name: packageName,
+              version,
+            },
           },
           modelType: 'layers',
         } as ModelDefinition);
@@ -172,9 +178,11 @@ describe('loadModel browser tests', () => {
         });
         await expect(() => fetchModel({
           path: modelPath,
-          packageInformation: {
-            name: packageName,
-            version,
+          _internals: {
+            packageInformation: {
+              name: packageName,
+              version,
+            },
           },
           modelType: 'layers',
         } as ModelDefinition))

--- a/packages/upscalerjs/src/loadModel.browser.ts
+++ b/packages/upscalerjs/src/loadModel.browser.ts
@@ -38,7 +38,9 @@ export const getLoadModelErrorMessage = (modelPath: string, packageInformation: 
 export async function fetchModel<M extends ModelType, R = M extends 'graph' ? tf.GraphModel : tf.LayersModel>({
   path: modelPath,
   modelType,
-  packageInformation,
+  _internals: {
+    packageInformation,
+  } = {},
 }: {
   modelType: M;
 } & Omit<ParsedModelDefinition, 'modelType'>): Promise<R> {

--- a/packages/upscalerjs/src/loadModel.node.test.ts
+++ b/packages/upscalerjs/src/loadModel.node.test.ts
@@ -116,10 +116,12 @@ describe('loadModel.node', () => {
     it('returns model path if given package information', () => {
       resolver.mockImplementation(getResolver(() => './node_modules/@upscalerjs/default-model/dist/foo/foo.ts'));
       expect(getModelPath({
-        packageInformation: {
-          name: 'baz',
-          version: '1.0.0',
-        }, 
+        _internals: {
+          packageInformation: {
+            name: 'baz',
+            version: '1.0.0',
+          },
+        },
         path: 'some-model',
         scale: 2,
         modelType: 'layers',

--- a/packages/upscalerjs/src/loadModel.node.ts
+++ b/packages/upscalerjs/src/loadModel.node.ts
@@ -26,7 +26,7 @@ export const getModuleFolder = (name: string): string => {
   return match;
 };
 
-export const getModelPath = ({ packageInformation, path: modelPath, }: ParsedModelDefinition): string => {
+export const getModelPath = ({ _internals: { packageInformation } = {}, path: modelPath, }: ParsedModelDefinition): string => {
   if (packageInformation) {
     const moduleFolder = getModuleFolder(packageInformation.name);
     return `file://${path.resolve(moduleFolder, modelPath)}`;

--- a/packages/upscalerjs/src/loadModel.node.ts
+++ b/packages/upscalerjs/src/loadModel.node.ts
@@ -26,7 +26,7 @@ export const getModuleFolder = (name: string): string => {
   return match;
 };
 
-export const getModelPath = ({ _internals: { packageInformation } = {}, path: modelPath, }: ParsedModelDefinition): string => {
+export const getModelPath = ({ _internals: { packageInformation, } = {}, path: modelPath, }: ParsedModelDefinition): string => {
   if (packageInformation) {
     const moduleFolder = getModuleFolder(packageInformation.name);
     return `file://${path.resolve(moduleFolder, modelPath)}`;

--- a/scripts/package-scripts/benchmark/performance/utils/SpeedBenchmarker.ts
+++ b/scripts/package-scripts/benchmark/performance/utils/SpeedBenchmarker.ts
@@ -434,7 +434,7 @@ const benchmarkModel: BenchmarkModel = async (
       const upscalerOpts = {
         model: {
           ...model,
-          packageInformation: undefined,
+          _internals: undefined,
           meta: undefined,
           path: `/models/${packageName}/${model.path}`,
         }

--- a/scripts/package-scripts/benchmark/performance/utils/UpscalerModel.ts
+++ b/scripts/package-scripts/benchmark/performance/utils/UpscalerModel.ts
@@ -159,7 +159,7 @@ export const getUpscalerFromExports = async (tf: TF, modelPackageFolder: string,
     const { require: importPath, } = value;
     const pathToModel = getPathToModel(modelPackageFolder, importPath, value);
     const modelDefinitionFn = (await import(pathToModel)).default;
-    const { packageInformation, ...modelDefinition } = modelDefinitionFn(tf) as ModelDefinition;
+    const { _internals, ...modelDefinition } = modelDefinitionFn(tf) as ModelDefinition;
 
     const modelPath = path.resolve(modelPackageFolder, modelDefinition.path);
     const model = {

--- a/scripts/package-scripts/create-new-model-folder.ts
+++ b/scripts/package-scripts/create-new-model-folder.ts
@@ -258,9 +258,11 @@ const getModelDefinition = (scale: 2 | 3 | 4 | 8, architecture: Size, modelPath:
     scale,
     channels: 3,
     path: modelPath,
-    packageInformation: {
-      name: NAME,
-      version: VERSION,
+    _internals: {
+      packageInformation: {
+        name: NAME,
+        version: VERSION,
+      },
     },
     meta,
     preprocess,
@@ -285,9 +287,11 @@ const modelDefinition: ModelDefinitionFn = () => ({
   scale: SCALE,
   channels: 3,
   path: 'models/${modelName}/model.json',
-  packageInformation: {
-    name: NAME,
-    version: VERSION,
+  _internals: {
+    packageInformation: {
+      name: NAME,
+      version: VERSION,
+    },
   },
   meta: {
   },


### PR DESCRIPTION
Moves packageInformation under an _internals variable, to further disambiguate that packageInformation is not meant to be a user-facing variable.

Future PRs will move `path` to an internal path variable, which will enable users to easily provide a custom path pointing to a locally hosted model.