### PR TITLE
Make model type optional

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,9 +44,9 @@ export type Teardown = (tf: TF) => (void | Promise<void>);
 
 export interface ModelDefinition {
   /**
-   * The type of the model. Can be 'graph' or 'layer'.
+   * The type of the model. Can be 'graph' or 'layer'. Defaults to 'layer'.
    */
-  modelType: ModelType;
+  modelType?: ModelType;
   /**
    * Path to a model.json file.
    */

--- a/packages/upscalerjs/src/loadModel.browser.ts
+++ b/packages/upscalerjs/src/loadModel.browser.ts
@@ -39,7 +39,7 @@ export const getLoadModelErrorMessage = (errs: Errors, modelPath: string, intern
 ].join('\n'));
 
 export async function fetchModel<M extends ModelType, R = M extends 'graph' ? tf.GraphModel : tf.LayersModel>(modelConfiguration: {
-  modelType: M;
+  modelType?: M;
 } & Omit<ParsedModelDefinition, 'modelType'>): Promise<R> {
   const { modelType, _internals, path: modelPath, } = modelConfiguration;
   if (modelPath) {


### PR DESCRIPTION
`modelType` should default to `layer` if not provided. This is historically how things functioned (until recently, UpscalerJS only supported layer model types) and will avoid a large scale rewrite of tutorials and other material, along with less configuration for the end user.