### PR TITLE
Introduce a common package to monorepo

### DIFF
--- a/internals/common/package.json
+++ b/internals/common/package.json
@@ -1,0 +1,62 @@
+{
+  "name": "@internals/common",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./models": "./dist/models.js",
+    "./package-json": "./dist/package-json.js",
+    "./tmp-dir": "./dist/tmp-dir.js",
+    "./constants": "./dist/constants.js",
+    "./logger": "./dist/logger.js",
+    "./git": "./dist/git.js",
+    "./packages": "./dist/packages.js",
+    "./npm": "./dist/npm.js",
+    "./get-hashed-name": "./dist/get-hashed-name.js",
+    "./tfjs-library": "./dist/tfjs-library.js",
+    "./types": "./dist/types.js",
+    "./fs": "./dist/fs.js",
+    "./get-template": "./dist/get-template.js",
+    "./get-port": "./dist/get-port.js",
+    "./pluralize": "./dist/pluralize.js"
+  },
+  "version": "0.1.0",
+  "description": "Constants and shared utility functions for the UpscalerJS monorepo",
+  "author": "Kevin Scott",
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "ejs": "^3.1.9",
+    "fs-extra": "latest",
+    "get-port": "^7.0.0"
+  },
+  "wireit": {
+    "build": {
+      "command": "tsc",
+      "files": [
+        "src/**/*.ts",
+        "!src/**/*.test.ts",
+        "package.json",
+        "vitest.config.ts",
+        "tsconfig.json"
+      ],
+      "output": [
+        "dist/**"
+      ]
+    },
+    "test": {
+      "command": "vitest"
+    }
+  },
+  "scripts": {
+    "build": "wireit",
+    "test": "wireit"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "devDependencies": {
+    "@types/ejs": "^3.1.2",
+    "vitest": "latest",
+    "vitest-mock-process": "^1.0.4"
+  }
+}

--- a/internals/common/src/constants.ts
+++ b/internals/common/src/constants.ts
@@ -1,0 +1,24 @@
+import path from 'path';
+import * as url from 'url';
+
+const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+export const ROOT_DIR = path.resolve(__dirname, '../../../');
+export const MODELS_DIR = path.resolve(ROOT_DIR, 'models');
+export const EXAMPLES_DIR = path.resolve(ROOT_DIR, 'examples');
+export const TEST_DIR = path.resolve(ROOT_DIR, 'test');
+export const FIXTURES_DIR = path.resolve(TEST_DIR, '__fixtures__');
+
+export const DOCS_DIR = path.resolve(ROOT_DIR, 'docs');
+export const ASSETS_DIR = path.resolve(DOCS_DIR, 'assets/assets');
+
+export const TMP_DIR = path.resolve(ROOT_DIR, 'tmp');
+export const DEV_DIR = path.resolve(ROOT_DIR, 'dev');
+export const PACKAGES_DIR = path.resolve(ROOT_DIR, 'packages');
+
+export const UPSCALER_DIR = path.resolve(PACKAGES_DIR, 'upscalerjs');
+export const CORE_DIR = path.resolve(PACKAGES_DIR, 'core');
+export const SHARED_DIR = path.resolve(PACKAGES_DIR, 'shared');
+export const WRAPPER_DIR = path.resolve(PACKAGES_DIR, 'upscalerjs-wrapper');
+
+export const INTERNALS_DIR = path.resolve(ROOT_DIR, 'internals');
+export const CLI_DIR = path.resolve(INTERNALS_DIR, 'cli')

--- a/internals/common/src/fs.ts
+++ b/internals/common/src/fs.ts
@@ -1,0 +1,35 @@
+import _fsExtra from 'fs-extra';
+import path from 'path';
+
+const {
+  writeFile: _writeFile,
+  copyFile: _copyFile,
+  mkdirp: _mkdirp,
+  ...fsExtra
+} = _fsExtra as typeof _fsExtra & {
+  mkdirp: (pathname: string) => Promise<void>;
+};
+
+export const writeFile = async (pathname: string, contents: string, encoding: 'utf-8' | 'base64' = 'utf-8') => {
+  await _mkdirp(path.dirname(pathname));
+  await _writeFile(pathname, contents, encoding);
+};
+
+export const copyFile = async (srcpath: string, targetpath: string) => {
+  await _mkdirp(path.dirname(targetpath));
+  await _copyFile(srcpath, targetpath);
+};
+
+export const readFile = async (pathname: string) => {
+  const contents = await fsExtra.readFile(pathname, 'utf-8');
+  return contents;
+};
+
+export const exists = fsExtra.exists;
+export const mkdirp = _mkdirp;
+export const readdir = fsExtra.readdir;
+export const stat = fsExtra.stat;
+export const readFileSync = fsExtra.readFileSync;
+export const unlink = fsExtra.unlink;
+export const symlink = fsExtra.symlink;
+export const copy = fsExtra.copy;

--- a/internals/common/src/get-hashed-name.ts
+++ b/internals/common/src/get-hashed-name.ts
@@ -1,0 +1,5 @@
+import crypto from 'crypto';
+
+const getRandomString = () => `${new Date().getTime()}${Math.random()}`;
+
+export const getHashedName = (contents?: string) => crypto.createHash('md5').update(contents || getRandomString()).digest('hex'); //skipcq: JS-D003

--- a/internals/common/src/get-port.ts
+++ b/internals/common/src/get-port.ts
@@ -1,0 +1,1 @@
+export { default as getPort } from 'get-port';

--- a/internals/common/src/get-template.ts
+++ b/internals/common/src/get-template.ts
@@ -1,0 +1,29 @@
+import { readFile } from '@internals/common/fs';
+import { compile } from 'ejs';
+
+const parseValue = (value: unknown) => {
+  if (value === undefined) {
+    return 'undefined';
+  }
+  return value;
+};
+
+export const getTemplate = async (
+  templatePath: string,
+  args: Record<string, unknown> = {},
+) => {
+  try {
+    return await compile(await readFile(templatePath))(Object.entries(args).reduce<Record<string, unknown>>((obj, [key, value]) => {
+      return {
+        ...obj,
+        [key]: parseValue(value),
+      };
+    }, {}));
+  } catch (e) {
+    if (e instanceof Error) {
+      console.error(`Error while compiling template ${templatePath} with args ${JSON.stringify(args, null, 2)}: ${e.message}`);
+    }
+    throw e;
+  }
+};
+

--- a/internals/common/src/git.ts
+++ b/internals/common/src/git.ts
@@ -1,0 +1,16 @@
+import { exec } from 'child_process';
+
+export const getCurrentBranch = () => new Promise<string>((resolve, reject) => {
+  exec('git rev-parse --abbrev-ref HEAD', (err, stdout, _stderr) => {
+    if (err) {
+      reject(err);
+    }
+
+    if (typeof stdout === 'string') {
+      resolve(stdout.trim());
+    } else {
+      reject(new Error('stdout is not a string'));
+    }
+  });
+});
+

--- a/internals/common/src/logger.test.ts
+++ b/internals/common/src/logger.test.ts
@@ -1,0 +1,87 @@
+import chalk from 'chalk';
+import { vi } from 'vitest';
+import { rimraf } from 'rimraf';
+import { isLogLevel, log, parseMessage, setLogLevel, logTypes } from './logger.js';
+import * as mockProcess from 'vitest-mock-process';
+
+vi.mock('rimraf', async () => {
+  const actual = await vi.importActual("rimraf") as typeof rimraf;
+  return {
+    ...actual,
+    rimraf: vi.fn(),
+  };
+});
+
+describe('logger', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('isLogLevel', () => {
+    it('returns true if a valid log level', () => {
+      expect(isLogLevel('error')).toBe(true);
+      expect(isLogLevel('warn')).toBe(true);
+      expect(isLogLevel('info')).toBe(true);
+      expect(isLogLevel('verbose')).toBe(true);
+    });
+
+    it('returns false if not a valid log level', () => {
+      expect(isLogLevel('foo')).toBe(false);
+    });
+  });
+
+  describe('parseMessage', () => {
+    it('parses a string message', () => {
+      expect(parseMessage('foo')).toEqual('foo');
+    });
+
+    it('parses an array of string messages', () => {
+      expect(parseMessage('foo', 'bar', 'baz')).toEqual('foo bar baz');
+    });
+
+    it('parses out a boolean', () => {
+      expect(parseMessage(true)).toEqual(chalk.yellow('true'));
+      expect(parseMessage(false)).toEqual(chalk.yellow('false'));
+    });
+
+    it('parses out a number', () => {
+      expect(parseMessage(123)).toEqual(chalk.yellow('123'));
+    });
+
+    it('parses out an object', () => {
+      expect(parseMessage({ foo: 'bar' })).toEqual('{"foo":"bar"}');
+    });
+
+    it('parses out a combo of stuff', () => {
+      expect(parseMessage({ foo: 'bar' }, 'baz', 123, true)).toEqual(`{"foo":"bar"} baz ${chalk.yellow(123)} ${chalk.yellow('true')}`);
+    });
+  });
+
+  describe('log', () => {
+    let mockStdout: ReturnType<typeof mockProcess.mockProcessStdout>;
+    let mockStderr: ReturnType<typeof mockProcess.mockProcessStderr>;
+
+    beforeEach(() => {
+      mockStdout = mockProcess.mockProcessStdout();
+      mockStderr = mockProcess.mockProcessStderr();
+    });
+
+    it('logs if level is greater than valid', () => {
+      setLogLevel('info');
+      log('warn', ['foo']);
+      expect(mockStderr).toHaveBeenCalledWith(logTypes.warn('foo\n'));
+    });
+
+    it('logs if level is equal to valid', () => {
+      setLogLevel('info');
+      log('info', ['foo']);
+      expect(mockStdout).toHaveBeenCalledWith(logTypes.info('foo\n'));
+    });
+
+    it('ignores log if below current log level', () => {
+      setLogLevel('info');
+      log('verbose', ['foo']);
+      expect(mockStdout).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/internals/common/src/logger.ts
+++ b/internals/common/src/logger.ts
@@ -1,0 +1,64 @@
+import chalk, { ChalkInstance } from 'chalk';
+
+export type LogLevel = 'info' | 'warn' | 'error' | 'verbose';
+
+export const logLevels = [
+  'error',
+  'warn',
+  'info',
+  'verbose',
+];
+
+export const isLogLevel = (logType: unknown): logType is LogLevel => typeof logType === 'string' && ['error', 'warn', 'info', 'verbose'].includes(logType);
+
+export const DEFAULT_LOG_LEVEL: LogLevel = isLogLevel(process.env.logLevel) ? process.env.logLevel : 'info';
+
+const level: { level: LogLevel } = {
+  level: DEFAULT_LOG_LEVEL,
+}
+
+export const logTypes: Record<LogLevel, ChalkInstance> = {
+  error: chalk.bold.red,
+  warn: chalk.hex('#FFA500'), // Orange color
+  info: chalk.bold.blue,
+  verbose: chalk.green,
+};
+
+export const parseMessage = (...message: unknown[]): string => message.map(m => {
+  if (Array.isArray(m)) {
+    return parseMessage(...m);
+  }
+  if (typeof m === 'object' && m !== null) {
+    return JSON.stringify(m);
+  }
+  if (m === true || m === false || typeof m === 'number') {
+    return chalk.yellow(m.toString());
+  }
+  return m;
+}).filter(Boolean).join(' ');
+
+const getConsoleLogger = (type: LogLevel) => type === 'error' || type === 'warn' ? console.error : console.log;
+
+export const log = (type: LogLevel, message: unknown[]) => {
+  if (logLevels.indexOf(type) <= logLevels.indexOf(level.level)) {
+    const chalkType = logTypes[type];
+    const parsedMessage = chalkType(`${parseMessage(...message)}`);
+    getConsoleLogger(type)(parsedMessage);
+  }
+};
+
+export const setLogLevel = (newLevel: LogLevel) => {
+  if (!isLogLevel(newLevel)) {
+    throw new Error(`Invalid log type provided: ${newLevel}`);
+  }
+  level.level = newLevel;
+};
+
+export const getLogLevel = () => level.level;
+
+export const info = (...message: unknown[]) => log('info', message);
+export const warn = (...message: unknown[]) => log('warn', message);
+export const error = (...message: unknown[]) => log('error', message);
+export const verbose = (...message: unknown[]) => log('verbose', message);
+
+export const output = (...message: unknown[]) => console.log(chalk.cyan(...message));

--- a/internals/common/src/models.ts
+++ b/internals/common/src/models.ts
@@ -1,0 +1,140 @@
+import { readdir, exists, readFile, stat } from '@internals/common/fs';
+import path from 'path';
+import { getPackageJSON, getPackageJSONExports, PackageJSONExport } from './package-json.js';
+import { MODELS_DIR } from '@internals/common/constants';
+import { Environment } from './types.js';
+
+export const EXCLUDED = ['dist', 'types', 'node_modules', 'docs'];
+export const PRIVATE_MODEL_PACKAGE_NAMES = ['pixel-upsampler'];
+
+const isValidModelPackage = async (file: string, includeExperimental: boolean) => {
+  const modelDir = path.resolve(MODELS_DIR, file);
+  if (EXCLUDED.includes(file) || !(await stat(modelDir)).isDirectory()) {
+    return false;
+  }
+
+  const packageJSONPath = path.resolve(modelDir, 'package.json');
+
+  if (!(await exists(packageJSONPath))) {
+    return false;
+  }
+
+  if (includeExperimental === false) {
+    const packageJSON = JSON.parse(await readFile(packageJSONPath));
+    const experimental = packageJSON['@upscalerjs']?.['model']?.['experimental'];
+    if (experimental) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+// export interface PackageAndModel { packageDirectory: string, model: AvailableModel };
+
+const getAllModelPackages = async (includeExperimental = false) => {
+  const dirContents = await readdir(MODELS_DIR);
+  const filters: boolean[] = await Promise.all(dirContents.map(file => isValidModelPackage(file, includeExperimental)));
+  const packageDirectoryNames = dirContents.reduce<string[]>((acc, file, i) => filters[i] ? acc.concat(file) : acc, []);
+  if (packageDirectoryNames.length === 0) {
+    throw new Error('No valid directories could be found found');
+  }
+  return packageDirectoryNames.sort();
+}
+
+const getAllAvailableModels = async (packageName: string): Promise<AvailableModel[]> => {
+  const modelPackageDir = path.resolve(MODELS_DIR, packageName);
+  const umdNamesPath = path.resolve(modelPackageDir, 'umd-names.json');
+  if (!await exists(umdNamesPath)) {
+    throw new Error(`No umd-names.json file found at ${umdNamesPath}`);
+  }
+  const umdNames = JSON.parse(await readFile(umdNamesPath))
+  const packageJSONExports = await getPackageJSONExports(modelPackageDir);
+  return packageJSONExports.filter(k => k[0] !== '.').map(([key, value]) => {
+    const umdName = umdNames[key];
+    if (umdName === undefined) {
+      throw new Error(`No UMD name defined for ${packageName}/umd-names.json for ${key}`);
+    }
+    return {
+      key,
+      umdName,
+      value,
+    };
+  });
+};
+
+const getAllModels = async (packageDirectoryNames: Promise<string[]>) => {
+  const modelPackagesAndModels: ModelInformation[] = [];
+  await Promise.all((await packageDirectoryNames).map(async packageDirectoryName => {
+    if (!packageDirectoryName) {
+      throw new Error('Missing package name in getAllAvailableModelPackagesAndModels');
+    }
+    const modelPackageDir = path.resolve(MODELS_DIR, packageDirectoryName);
+    const [
+      models,
+      packageJSON,
+    ] = await Promise.all([
+      getAllAvailableModels(packageDirectoryName),
+      getPackageJSON(modelPackageDir),
+    ]);
+
+    const { name: packageName } = packageJSON;
+    if (!packageName) {
+      throw new Error(`No name defined on package json for folder ${packageDirectoryName}`)
+    }
+
+    for (const model of models) {
+      modelPackagesAndModels.push({
+        modelName: model.key,
+        packageName,
+        modelUMDName: model.umdName, 
+        packageDirectoryName,
+        modelExport: model.value,
+      });
+    }
+  }));
+  return modelPackagesAndModels;
+};
+
+export interface ModelInformation {
+  modelName: string;
+  packageName: string;
+  modelUMDName: string;
+  packageDirectoryName: string;
+  modelExport: string | PackageJSONExport;
+}
+export const isValidModelInformation = (model: unknown): model is ModelInformation => Boolean(model) && model !== null && typeof model === 'object' && 'packageDirectoryName' in model;
+export const ALL_MODEL_PACKAGE_DIRECTORY_NAMES = getAllModelPackages();
+export const ALL_MODELS: Promise<ModelInformation[]> = getAllModels(ALL_MODEL_PACKAGE_DIRECTORY_NAMES);
+
+interface AvailableModel {
+  key: string;
+  umdName: string;
+  value: string | PackageJSONExport;
+}
+
+export const getSupportedPlatforms = async (packageName: string, modelName: string): Promise<Environment[]> => {
+  if (!packageName) {
+    throw new Error('Missing package name')
+  }
+  const packageJSONPath = path.resolve(MODELS_DIR, packageName);
+  const packageJSON = await getPackageJSON(packageJSONPath);
+  return packageJSON['@upscalerjs']?.models?.[modelName]?.supportedPlatforms || ['clientside', 'serverside'];
+};
+
+const getPackagesAndModelsMatchingEnvironment = async (environment: Environment, packagesAndModels: ModelInformation[]) => {
+  const filteredPackagesAndModels: ModelInformation[] = [];
+  await Promise.all(packagesAndModels.map(async (modelInformation) => {
+    const supportedPlatforms = await getSupportedPlatforms(modelInformation.packageDirectoryName, modelInformation.modelName);
+    if (supportedPlatforms.includes(environment)) {
+      filteredPackagesAndModels.push(modelInformation);
+    }
+  }));
+  return filteredPackagesAndModels;
+};
+
+
+export const getPackagesAndModelsForEnvironment = async (environment: Environment) => {
+  const packagesAndModels = await ALL_MODELS;
+  return getPackagesAndModelsMatchingEnvironment(environment, packagesAndModels);
+};

--- a/internals/common/src/npm.test.ts
+++ b/internals/common/src/npm.test.ts
@@ -1,0 +1,51 @@
+import { vi } from 'vitest';
+import { ChildProcess, spawn } from 'child_process';
+import { runNPMCommand } from "./npm.js";
+
+vi.mock('child_process', () => {
+  return {
+    spawn: vi.fn(),
+  }
+});
+
+describe('run-npm-command', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('if the command throws an error, it should reject', async () => {
+    const error = 'huzzah';
+    vi.mocked(spawn).mockImplementation(() => ({
+      on: (event: string, callback: (...args: unknown[]) => unknown) => {
+        if (event === 'error') {
+          callback(error);
+        }
+        return 'foo' as unknown as ChildProcess;
+      },
+    }));
+    await expect(() => runNPMCommand([], 'foo')).rejects.toThrow(error);
+  });
+
+  it('if the command exits with a non-0 exit code, it should reject with that code', async () => {
+    const code = 1;
+    vi.mocked(spawn).mockImplementation(() => ({
+      on: (event: string, callback: (...args: unknown[]) => unknown) => {
+        if (event === 'close') {
+          callback(`${code}`); // skipcq: JS-0255
+        }
+      },
+    }));
+    await expect(() => runNPMCommand([], 'foo')).rejects.toThrow(`${code}`);
+  });
+
+  it('if the command exits with a 0 exit code, it should resolve', async () => {
+    vi.mocked(spawn).mockImplementation(() => ({
+      on: (event: string, callback: (...args: unknown[]) => unknown) => {
+        if (event === 'close') {
+          callback(0); // skipcq: JS-0255
+        }
+      },
+    }));
+    await runNPMCommand([], 'foo');
+  });
+});

--- a/internals/common/src/npm.ts
+++ b/internals/common/src/npm.ts
@@ -1,0 +1,87 @@
+import { spawn } from 'child_process';
+import { getLogLevel, verbose } from './logger.js';
+
+const parseCommand = (_command: string | string[]) => {
+  const command = Array.isArray(_command) ? _command : _command.split(' ');
+  if (command[0] === 'npm' || command[0] === 'pnpm') {
+    return command.slice(1);
+  }
+  return command;
+};
+
+export const runNPMCommand = (
+  command: string | string[],
+  cwd: string,
+  runner: 'npm' | 'pnpm' = 'npm',
+) => new Promise<void>((resolve, reject) => {
+  const child = spawn(runner, parseCommand(command), {
+    shell: true,
+    cwd,
+    stdio: "inherit"
+  });
+
+  child.on('error', reject);
+
+  child.on('close', (code) => {
+    if (code === 0) {
+      resolve();
+    } else {
+      reject(code);
+    }
+  });
+});
+
+
+export const npmInstall = async (cwd: string, {
+  isSilent = false,
+  registryURL,
+}: {
+  isSilent?: boolean;
+  registryURL?: string;
+} = {}) => {
+  const logLevel = getLogLevel();
+  const command = [
+    'npm',
+    'install',
+    isSilent ? '--silent' : '',
+    '--no-fund',
+    '--no-audit',
+    '--no-package-lock',
+    '--loglevel',
+    logLevel,
+    registryURL ? `--registry ${registryURL}` : '',
+  ].filter(Boolean);
+  verbose(`${command.join(' ')} in ${cwd}`);
+  await runNPMCommand(command, cwd);
+
+};
+
+export const pnpmInstall = async (cwd: string, {
+  // isSilent = false,
+  // registryURL,
+}: {
+  // isSilent?: boolean;
+  // registryURL?: string;
+} = {}) => {
+  // const logLevel = getLogLevel();
+  const command = [
+    'pnpm',
+    'install',
+    '--ignore-scripts',
+    // isSilent ? '--silent' : '',
+    // '--no-fund',
+    // '--no-audit',
+    // '--no-package-lock',
+    // '--loglevel',
+    // logLevel,
+    // registryURL ? `--registry ${registryURL}` : '',
+  ].filter(Boolean);
+  verbose(`${command.join(' ')} in ${cwd}`);
+  await runNPMCommand(command, cwd);
+
+};
+
+export const runPNPMCommand = (
+  command: Parameters<typeof runNPMCommand>[0],
+  cwd: Parameters<typeof runNPMCommand>[1]
+) => runNPMCommand(command, cwd, 'pnpm');

--- a/internals/common/src/package-json.test.ts
+++ b/internals/common/src/package-json.test.ts
@@ -1,0 +1,90 @@
+import { getPackageJSONExports } from './package-json.js';
+import { vi } from 'vitest';
+import * as fs from '@internals/common/fs';
+
+const { readFile } = fs;
+
+vi.mock('@internals/common/fs', async () => {
+  const actual = await vi.importActual("@internals/common/fs") as typeof fs;
+  return {
+    default: {
+      ...actual,
+      // exists: vi.fn(),
+      // readdir: vi.fn().mockImplementation(() => Promise.resolve([])),
+      readFile: vi.fn(),
+      // stat: vi.fn(),
+    },
+  }
+});
+
+describe('package-json', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getPackageJSONExports', () => {
+    it('gets exports field from a package json for a single string exports', async () => {
+      const mockReadFile = () => Promise.resolve(JSON.stringify({
+        "exports": {
+          ".": 'foobar',
+        },
+      }));
+
+      vi.mocked(readFile).mockImplementation(mockReadFile as unknown as typeof readFile);
+
+      expect(await getPackageJSONExports('foo')).toEqual([['.', 'foobar']])
+    });
+
+    it('gets exports field from a package json for a single nested exports', async () => {
+      const mockReadFile = () => Promise.resolve(JSON.stringify({
+        "exports": {
+          ".": {
+            "require": "./dist/cjs/models/esrgan-thick/src/index.js",
+            "import": "./dist/esm/models/esrgan-thick/src/index.js"
+          }
+        },
+      }));
+
+      vi.mocked(readFile).mockImplementation(mockReadFile as unknown as typeof readFile);
+
+      expect(await getPackageJSONExports('foo')).toEqual([['.', {
+        "require": "./dist/cjs/models/esrgan-thick/src/index.js",
+        "import": "./dist/esm/models/esrgan-thick/src/index.js"
+      }]])
+    });
+
+    it('gets exports field from a package json for a multiple nested exports', async () => {
+      const mockReadFile = () => Promise.resolve(JSON.stringify({
+        "exports": {
+          "./2x": {
+            "require": "./dist/cjs/models/esrgan-thick/src/2x.js",
+            "import": "./dist/esm/models/esrgan-thick/src/2x.js"
+          },
+          ".": {
+            "require": "./dist/cjs/models/esrgan-thick/src/index.js",
+            "import": "./dist/esm/models/esrgan-thick/src/index.js"
+          }
+        },
+      }));
+
+      vi.mocked(readFile).mockImplementation(mockReadFile as unknown as typeof readFile);
+
+      expect(await getPackageJSONExports('foo')).toEqual([
+        ['./2x', {
+          "require": "./dist/cjs/models/esrgan-thick/src/2x.js",
+          "import": "./dist/esm/models/esrgan-thick/src/2x.js"
+        }],
+      ]);
+    });
+
+    it('throws if given a bad exports field', async () => {
+      const mockReadFile = () => Promise.resolve(JSON.stringify({
+        "exports": 'foo',
+      }));
+
+      vi.mocked(readFile).mockImplementation(mockReadFile as unknown as typeof readFile);
+
+      await expect(() => getPackageJSONExports('foo')).rejects.toThrow();
+    });
+  });
+});

--- a/internals/common/src/package-json.ts
+++ b/internals/common/src/package-json.ts
@@ -1,0 +1,86 @@
+import path from 'path';
+import { readFile } from '@internals/common/fs';
+import { JSONSchemaForNPMPackageJsonFiles } from '@schemastore/package';
+import { ROOT_DIR } from './constants.js';
+import { writeFile } from './fs.js';
+
+export type PackageJSONExport = string | {
+  require: string;
+  import: string;
+};
+
+const isPackageJSONExports = (exports: unknown): exports is {
+  [index: string]: PackageJSONExport;
+} => {
+  if (typeof exports !== 'object' || exports === null) {
+    return false;
+  };
+  return Object.entries(exports).reduce((isValid, [_exportName, exportValue]) => {
+    return isValid === false ? false : typeof exportValue === 'string' || (typeof exportValue === 'object' && 'require' in exportValue && 'import' in exportValue);
+  }, true);
+};
+
+export const getPackageJSON = async (folder: string): Promise<JSONSchema> => {
+  const packageJSONPath = folder.endsWith('package.json') ? folder : path.resolve(folder, 'package.json');
+  return JSON.parse(await readFile(packageJSONPath));
+};
+
+export const getPackageJSONExports = async (modelFolder: string): Promise<Array<[string, PackageJSONExport]>> => {
+  const { exports } = await getPackageJSON(modelFolder);
+  if (!isPackageJSONExports(exports)) {
+    throw new Error(`Invalid exports field in package json for ${modelFolder}}: ${JSON.stringify(exports)}`);
+  }
+  return Object.entries(exports);
+};
+
+interface FakeExports {
+  [index: string]: string | FakeExports;
+}
+
+export type JSONSchema = JSONSchemaForNPMPackageJsonFiles & {
+  exports: FakeExports;
+};
+
+export type TransformPackageJsonFn = (packageJSON: JSONSchema, dir: string) => JSONSchema;
+export type PackageUpdaterLogger = (file: string) => (string | undefined);
+
+export const getPreparedFolderName = (file: string) => {
+  return file.split(`${ROOT_DIR}/`).pop();
+};
+
+export const getPackageJSONPath = (file: string) => {
+  if (file.endsWith('package.json')) {
+    return file;
+  }
+  return path.resolve(file, 'package.json');
+}
+
+export const writePackageJSON = async (file: string, contents: unknown) => {
+  const stringifiedContents = `${JSON.stringify(contents, null, 2)}\n`;
+  await writeFile(getPackageJSONPath(file), stringifiedContents);
+};
+
+export const getPackageJSONValue = (packageJSON: JSONSchema, depKey: string) => {
+  return depKey.split('.').reduce((json, key) => json?.[key], packageJSON);
+}
+
+type Value = JSONSchema[keyof JSONSchema];
+export const updatePackageJSONForKey = (packageJSON: JSONSchema, key: string, val: Value): JSONSchema => {
+  return getObj(packageJSON, key.split('.'), val);
+}
+
+function getObj(obj: JSONSchema, parts: string[], val: Value): JSONSchema {
+  if (parts.length === 1) {
+    return {
+      ...obj,
+      [parts[0]]: {
+        ...obj[parts[0]],
+        ...val,
+      }
+    };
+  }
+  return {
+    ...obj,
+    [parts[0]]: getObj(obj[parts[0]], parts.slice(1), val),
+  }
+}

--- a/internals/common/src/pluralize.test.ts
+++ b/internals/common/src/pluralize.test.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_SEPARATOR, EMPTY_ITEMS_ERROR, pluralize } from "./pluralize.js";
+
+describe("pluralize", () => {
+  it('throws if given no items', () => {
+    expect(() => pluralize([])).toThrow(EMPTY_ITEMS_ERROR);
+  });
+
+  it('returns a single item', () => {
+    expect(pluralize(['foo'])).toEqual('foo');
+  });
+
+  it('returns two items with a separator', () => {
+    expect(pluralize(['foo', 'bar'])).toEqual(`foo ${DEFAULT_SEPARATOR} bar`);
+  });
+
+  it('returns three items with commas and a separator', () => {
+    expect(pluralize(['foo', 'bar', 'baz'])).toEqual(`foo, bar, ${DEFAULT_SEPARATOR} baz`);
+  });
+
+  it('accepts a custom separator', () => {
+    expect(pluralize(['foo', 'bar', 'baz'], 'and')).toEqual('foo, bar, and baz');
+  });
+});

--- a/internals/common/src/pluralize.ts
+++ b/internals/common/src/pluralize.ts
@@ -1,0 +1,13 @@
+export const EMPTY_ITEMS_ERROR = new Error('Must provide at least one item to pluralize')
+export const DEFAULT_SEPARATOR = 'or';
+export const pluralize = (items: string[], separator = DEFAULT_SEPARATOR): string => {
+  if (items.length === 0) {
+    throw EMPTY_ITEMS_ERROR;
+  }
+  if (items.length <= 2) {
+    return items.join(` ${separator} `);
+  }
+
+  return `${items.slice(0, -1).join(', ')}, ${separator} ${items[items.length - 1]}`;
+};
+

--- a/internals/common/src/tfjs-library.test.ts
+++ b/internals/common/src/tfjs-library.test.ts
@@ -1,0 +1,60 @@
+import { vi } from 'vitest';
+import fsExtra from "fs-extra";
+import { TFJS_LIBRARY_TARGET_ERROR, getTFJSLibraryTargetFromPackageJSON } from './tfjs-library.js';
+const { readFile } = fsExtra;
+
+vi.mock('fs-extra', () => {
+  return {
+    default: {
+      readFile: vi.fn(),
+    },
+  }
+});
+
+describe('getTFJSLibraryTarget', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makeMock = (dependencies: Record<string, string>) => {
+    vi.mocked(readFile).mockImplementation(() => Promise.resolve(Buffer.from(JSON.stringify({
+      dependencies,
+    }))));
+  }
+
+  it('loads the correct package json from the right directory', async () => {
+    makeMock({
+      '@tensorflow/tfjs': '1.0.0',
+    });
+    expect(readFile).toHaveBeenCalledTimes(0);
+    expect(await getTFJSLibraryTargetFromPackageJSON('foo')).toBe('browser');
+    expect(readFile).toHaveBeenCalledWith(expect.stringContaining('foo/package.json'), expect.anything());
+  });
+
+  it('returns browser for @tensorflow/tfjs', async () => {
+    makeMock({
+      '@tensorflow/tfjs': '1.0.0',
+    });
+    expect(await getTFJSLibraryTargetFromPackageJSON('foo')).toBe('browser');
+  });
+
+  it('returns node for @tensorflow/tfjs-node', async () => {
+    makeMock({
+      '@tensorflow/tfjs-node': '1.0.0',
+    });
+    expect(await getTFJSLibraryTargetFromPackageJSON('foo')).toBe('node');
+  });
+
+  it('returns node-gpu for @tensorflow/tfjs-node-gpu', async () => {
+    makeMock({
+      '@tensorflow/tfjs-node-gpu': '1.0.0',
+    });
+    expect(await getTFJSLibraryTargetFromPackageJSON('foo')).toBe('node-gpu');
+  });
+
+  it('throws if no dependencies are found', async () => {
+    makeMock({
+    });
+    await expect(() => getTFJSLibraryTargetFromPackageJSON('foo')).rejects.toThrow(TFJS_LIBRARY_TARGET_ERROR('foo'));
+  });
+});

--- a/internals/common/src/tfjs-library.ts
+++ b/internals/common/src/tfjs-library.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import { readFile } from "@internals/common/fs";
+import { Environment } from './types.js';
+
+export type TFJSLibrary = 'browser' | 'node' | 'node-gpu';
+
+export const TFJS_LIBRARY_TARGET_ERROR = (dir: string) => new Error(`Could not determine valid TFJS dependency in directory ${dir}`);
+
+export const getTFJSLibraryTargetFromPackageJSON = async (dir: string): Promise<TFJSLibrary> => {
+  const packageJSON = JSON.parse(await readFile(path.resolve(dir, 'package.json')));
+  const deps = Object.keys(packageJSON.dependencies);
+  if (deps.includes('@tensorflow/tfjs')) {
+    return 'browser';
+  } else if (deps.includes('@tensorflow/tfjs-node')) {
+    return 'node';
+  } else if (deps.includes('@tensorflow/tfjs-node-gpu')) {
+    return 'node-gpu';
+  }
+
+  throw TFJS_LIBRARY_TARGET_ERROR(dir);
+};
+
+export const getTFJSLibraryFromTarget = (target: TFJSLibrary): string => {
+  if (target === 'node') {
+    return '@tensorflow/tfjs-node';
+  }
+  if (target === 'node-gpu') {
+    return '@tensorflow/tfjs-node-gpu';
+  }
+  return '@tensorflow/tfjs';
+}
+
+export const getEnvironmentFromTFJSLibrary = (library: TFJSLibrary): Environment => library === 'browser' ? 'clientside' : 'serverside';
+export const getTFJSLibraryFromEnvironment = (env: Environment): TFJSLibrary[] => env === 'clientside' ? ['browser'] : ['node', 'node-gpu'];

--- a/internals/common/src/tmp-dir.test.ts
+++ b/internals/common/src/tmp-dir.test.ts
@@ -1,0 +1,104 @@
+import * as fs from '@internals/common/fs';
+import { vi } from 'vitest';
+import { rimraf } from 'rimraf';
+import { makeTmpDir, withTmpDir } from "./tmp-dir.js";
+
+const { exists, mkdirp } = fs;
+
+vi.mock("@internals/common/fs", async () => {
+  const actual = await vi.importActual("@internals/common/fs") as typeof fs;
+  return {
+    default: {
+      ...actual,
+      exists: vi.fn(),
+      mkdirp: vi.fn(),
+    }
+  };
+});
+
+vi.mock('rimraf', async () => {
+  const actual = await vi.importActual("rimraf") as typeof rimraf;
+  return {
+    ...actual,
+    rimraf: vi.fn(),
+  };
+});
+
+describe('makeTmpDir', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('makes a random folder and returns it', async () => {
+    vi.mocked(exists).mockImplementation(() => Promise.resolve(true));
+    const folder = await makeTmpDir();
+    expect(typeof folder).toBe('string');
+    expect(mkdirp).toHaveBeenCalledWith(folder);
+    expect(exists).toHaveBeenCalledWith(folder);
+  });
+
+  it('makes a random folder at a given directory', async () => {
+    vi.mocked(exists).mockImplementation(() => Promise.resolve(true));
+    const folder = await makeTmpDir('foobarbaz');
+    expect(folder).toContain('foobarbaz')
+  });
+
+  it('throws if folder was not created', async () => {
+    vi.mocked(exists).mockImplementation(() => Promise.resolve(false));
+    await expect(() => makeTmpDir()).rejects.toThrow();
+  });
+});
+
+describe('withTmpDir', () => {
+  beforeEach(() => {
+    vi.mocked(exists).mockImplementation(() => Promise.resolve(true));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('makes a tmp dir and calls a callback in it', async () => {
+    const callback = vi.fn();
+    await withTmpDir(callback);
+    expect(callback).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('returns the response of callback', async () => {
+    const callback = vi.fn().mockResolvedValue('foo');
+    const response = await withTmpDir(callback);
+    expect(response).toBe('foo');
+  });
+
+  it('removes tmp directory by default', async () => {
+    expect(rimraf).not.toHaveBeenCalled();
+    await withTmpDir(vi.fn());
+    expect(rimraf).toHaveBeenCalled();
+  });
+
+  it('if it fails to remove tmp directory, console.error', async () => {
+    console.error = vi.fn();
+    expect(console.error).not.toHaveBeenCalled();
+    vi.mocked(rimraf).mockImplementation(() => {
+      throw new Error('WHOA')
+    });
+
+    await withTmpDir(vi.fn());
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('does not remove tmp directory if specified not to', async () => {
+    await withTmpDir(vi.fn(), {
+      removeTmpDir: false,
+    });
+    expect(rimraf).not.toHaveBeenCalled();
+  });
+
+  it('passes root dir if specified', async () => {
+    expect(rimraf).not.toHaveBeenCalled();
+    await withTmpDir(vi.fn(), {
+      rootDir: 'foobarbaz',
+    });
+    expect(rimraf).toHaveBeenCalledWith(expect.stringContaining('foobarbaz'));
+  });
+});

--- a/internals/common/src/tmp-dir.ts
+++ b/internals/common/src/tmp-dir.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { rimraf } from 'rimraf';
+import { TMP_DIR } from './constants.js';
+import { getHashedName } from './get-hashed-name.js';
+import { exists, mkdirp } from './fs.js';
+
+export const makeTmpDir = async (root = TMP_DIR): Promise<string> => {
+  const hashedName = getHashedName();
+  const folder = path.resolve(root, hashedName);
+  await mkdirp(folder);
+  if (!await exists(folder)) {
+    throw new Error(`Tmp directory ${folder} was not created`);
+  }
+  return folder;
+};
+
+
+interface WithTmpDirOpts {
+  rootDir?: string;
+  removeTmpDir?: boolean;
+}
+type WithTmpDirFn<T> = (tmp: string) => Promise<T>;
+export async function withTmpDir<T>(callback: WithTmpDirFn<T>, { rootDir, removeTmpDir = true }: WithTmpDirOpts = {}) {
+  const tmpDir = await makeTmpDir(rootDir);
+
+  let response: T;
+  try {
+    response = await callback(tmpDir);
+  }
+  finally {
+    try {
+      if (removeTmpDir) {
+        await rimraf(tmpDir);
+      }
+    }
+    catch (e) {
+      console.error(`An error has occurred while removing the temp folder at ${tmpDir}. Please remove it manually. Error: ${e}`);
+    }
+  }
+  return response;
+};

--- a/internals/common/src/types.ts
+++ b/internals/common/src/types.ts
@@ -1,0 +1,12 @@
+import { TFJSLibrary } from "./tfjs-library.js";
+
+export type OutputFormat = 'cjs' | 'esm' | 'umd';
+export type Environment = 'serverside' | 'clientside';
+
+export const isTFJSLibrary = (platform: unknown): platform is TFJSLibrary => typeof platform === 'string' && ['node', 'node-gpu', 'browser'].includes(platform);
+export const isOutputFormat = (outputFormat: unknown): outputFormat is OutputFormat => typeof outputFormat === 'string' && ['cjs', 'esm', 'umd'].includes(outputFormat);
+export const isEnvironment = (environment: unknown): environment is Environment => typeof environment === 'string' && ['serverside', 'clientside'].includes(environment);
+
+export type Action<T extends unknown[]> = (...args: T) => Promise<void>;
+
+export { TFJSLibrary } from './tfjs-library.js';

--- a/internals/common/tsconfig.json
+++ b/internals/common/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "importHelpers": true,
+    "module": "es2022",
+    "outDir": "./dist",
+    "rootDir": "src",
+    "strict": true,
+    "target": "es2022",
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node16",
+      "types": ["vitest/globals"]
+  },
+  "include": ["./src/**/*"],
+  "exclude": ["./src/**/*.test.ts"],
+  "ts-node": {
+    "esm": true
+  }
+}

--- a/internals/common/vitest.config.ts
+++ b/internals/common/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['**/*.test.ts'],
+    globals: true,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@babel/plugin-transform-modules-commonjs": "7.22.5",
     "@babel/preset-env": "7.22.10",
     "@babel/preset-typescript": "7.22.5",
+    "@internals/common": "workspace:*",
     "@internals/upscaler-cli": "workspace:*",
     "@rollup/plugin-commonjs": "25.0.4",
     "@rollup/plugin-node-resolve": "15.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 7.22.5
         version: 7.22.5(@babel/core@7.22.10)
+      '@internals/common':
+        specifier: workspace:*
+        version: link:internals/common
       '@internals/upscaler-cli':
         specifier: workspace:*
         version: link:internals/upscaler-cli
@@ -539,6 +542,31 @@ importers:
       wrangler:
         specifier: ^3.5.1
         version: 3.5.1
+
+  internals/common:
+    dependencies:
+      chalk:
+        specifier: ^5.3.0
+        version: 5.3.0
+      ejs:
+        specifier: ^3.1.9
+        version: 3.1.9
+      fs-extra:
+        specifier: latest
+        version: 11.1.1
+      get-port:
+        specifier: ^7.0.0
+        version: 7.0.0
+    devDependencies:
+      '@types/ejs':
+        specifier: ^3.1.2
+        version: 3.1.3
+      vitest:
+        specifier: latest
+        version: 0.34.5(jsdom@22.1.0)
+      vitest-mock-process:
+        specifier: ^1.0.4
+        version: 1.0.4(vitest@0.34.5)
 
   internals/upscaler-cli:
     dependencies:
@@ -5078,6 +5106,10 @@ packages:
       '@types/ms': 0.7.31
     dev: false
 
+  /@types/ejs@3.1.3:
+    resolution: {integrity: sha512-mv5T/JI/bu+pbfz1o+TLl1NF0NIBbjS0Vl6Ppz1YY9DkXfzZT0lelXpfS5i3ZS3U/p90it7uERQpBvLYoK8e4A==}
+    dev: true
+
   /@types/emscripten@1.39.6:
     resolution: {integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==}
     dev: true
@@ -6162,6 +6194,10 @@ packages:
     dependencies:
       tslib: 2.6.2
     dev: true
+
+  /async@3.2.4:
+    resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
+    dev: false
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -7916,6 +7952,12 @@ packages:
         optional: true
     dev: true
 
+  /deep-clone-fn@1.1.0:
+    resolution: {integrity: sha512-9EOa4OcoQhpBknAVdyVjlCFEtHD8lyC/P84NUy+FiJumMs9AQ39vNPvq8IySYjTqTqgO5ZAd2Bm+ATSjNKA/gw==}
+    dependencies:
+      rfdc: 1.3.0
+    dev: true
+
   /deep-eql@4.1.3:
     resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
     engines: {node: '>=6'}
@@ -8309,6 +8351,14 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  /ejs@3.1.9:
+    resolution: {integrity: sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+    dependencies:
+      jake: 10.8.7
+    dev: false
 
   /electron-to-chromium@1.4.461:
     resolution: {integrity: sha512-1JkvV2sgEGTDXjdsaQCeSwYYuhLRphRpc+g6EHTFELJXEiznLt3/0pZ9JuAOQ5p2rI3YxKTbivtvajirIfhrEQ==}
@@ -9141,6 +9191,12 @@ packages:
     requiresBuild: true
     dev: true
 
+  /filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
+    dependencies:
+      minimatch: 5.0.1
+    dev: false
+
   /filesize@8.0.7:
     resolution: {integrity: sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==}
     engines: {node: '>= 0.4.0'}
@@ -9351,7 +9407,6 @@ packages:
       graceful-fs: 4.2.11
       jsonfile: 6.1.0
       universalify: 2.0.0
-    dev: true
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -9487,6 +9542,11 @@ packages:
     resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
     engines: {node: '>=8'}
     dev: true
+
+  /get-port@7.0.0:
+    resolution: {integrity: sha512-mDHFgApoQd+azgMdwylJrv2DX47ywGq1i5VFJE7fZ0dttNq3iQMfsU4IvEgBHojA3KqEudyu7Vq+oN8kNaNkWw==}
+    engines: {node: '>=16'}
+    dev: false
 
   /get-source@2.0.12:
     resolution: {integrity: sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==}
@@ -10778,6 +10838,17 @@ packages:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  /jake@10.8.7:
+    resolution: {integrity: sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      async: 3.2.4
+      chalk: 4.1.2
+      filelist: 1.0.4
+      minimatch: 3.1.2
+    dev: false
 
   /jest-canvas-mock@2.5.2:
     resolution: {integrity: sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==}
@@ -12145,7 +12216,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       brace-expansion: 2.0.1
-    dev: true
 
   /minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
@@ -14480,6 +14550,10 @@ packages:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  /rfdc@1.3.0:
+    resolution: {integrity: sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==}
+    dev: true
+
   /rimraf@2.5.4:
     resolution: {integrity: sha512-Lw7SHMjssciQb/rRz7JyPIy9+bbUshEucPoLRvWqy09vC5zQixl8Uet+Zl+SROBB/JMWHJRdCk1qdxNWHNMvlQ==}
     hasBin: true
@@ -16647,6 +16721,15 @@ packages:
       rollup: 3.28.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
+
+  /vitest-mock-process@1.0.4(vitest@0.34.5):
+    resolution: {integrity: sha512-WFoSE8MLTanQJkZUZSEd2/9+O1RJKqYn5tUNh3mW/SAh1VL7D7cfcxkn2F7DlhsFI0ZPILxto0OI6XEmGYFyRA==}
+    peerDependencies:
+      vitest: <1
+    dependencies:
+      deep-clone-fn: 1.1.0
+      vitest: 0.34.5(jsdom@22.1.0)
     dev: true
 
   /vitest@0.34.2(jsdom@22.1.0):


### PR DESCRIPTION
Introduces an `@internals/common` package to the monorepo, to collect shared snippets and constants that are reused in various build scripts