### PR TITLE
Refactor out generated image import

### DIFF
--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -1,5 +1,5 @@
 import { tf, } from './dependencies.generated';
-import { CheckValidEnvironment, } from './types';
+import { CheckValidEnvironment, GetImageAsTensor, TensorAsBase64, } from './types';
 import { tensorAsClampedArray, } from './tensor-utils';
 import { isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from '@upscalerjs/core';
 
@@ -54,9 +54,9 @@ const getTensorFromInput = async (input: Input): Promise<tf.Tensor3D | tf.Tensor
 };
 
 export type Input = tf.Tensor3D | tf.Tensor4D | string | tf.FromPixelsInputs['pixels'];
-export const getImageAsTensor = async (
-  input: Input,
-): Promise<tf.Tensor4D> => {
+export const getImageAsTensor: GetImageAsTensor<Input> = async (
+  input,
+) => {
   const tensor = await getTensorFromInput(input);
 
   if (isThreeDimensionalTensor(tensor)) {
@@ -82,7 +82,7 @@ export const isHTMLImageElement = (pixels: Input): pixels is HTMLImageElement =>
   }
 };
 
-export const tensorAsBase64 = (tensor: tf.Tensor3D): string => {
+export const tensorAsBase64: TensorAsBase64 = (tensor) => {
   const arr = tensorAsClampedArray(tensor);
   const [height, width, ] = tensor.shape;
   const imageData = new ImageData(width, height);

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { tf, } from './dependencies.generated';
 import { tensorAsClampedArray, } from './tensor-utils';
 import { isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, isString, hasValidChannels, } from '@upscalerjs/core';
-import { CheckValidEnvironment, } from './types';
+import { CheckValidEnvironment, GetImageAsTensor, TensorAsBase64, } from './types';
 
 export const getInvalidTensorError = (input: tf.Tensor): Error => new Error(
   [
@@ -61,9 +61,9 @@ const getTensorFromInput = (input: Input): tf.Tensor3D | tf.Tensor4D => {
 export type Input = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
 
 /* eslint-disable @typescript-eslint/require-await */
-export const getImageAsTensor = async (
-  input: Input,
-): Promise<tf.Tensor4D> => {
+export const getImageAsTensor: GetImageAsTensor<Input> = async (
+  input,
+) => {
   const tensor = getTensorFromInput(input);
 
   if (!hasValidChannels(tensor)) {
@@ -83,7 +83,7 @@ export const getImageAsTensor = async (
   throw getInvalidTensorError(tensor);
 };
 
-export const tensorAsBase64 = (tensor: tf.Tensor3D): string => {
+export const tensorAsBase64: TensorAsBase64 = (tensor) => {
   const arr = tensorAsClampedArray(tensor);
   return Buffer.from(arr).toString('base64');
 };

--- a/packages/upscalerjs/src/tensor-utils.test.ts
+++ b/packages/upscalerjs/src/tensor-utils.test.ts
@@ -18,26 +18,12 @@ import {
   isTensor,
  } from '@upscalerjs/core';
 import {
-  tensorAsBase64,
-  getImageAsTensor,
-} from './image.generated';
-import {
   GET_INVALID_SHAPED_TENSOR,
   GET_UNDEFINED_TENSORS_ERROR,
 } from './errors-and-warnings';
 
-import type * as imageGenerated from './image.generated';
 import type * as dependenciesGenerated from './dependencies.generated';
 import type * as core from '@upscalerjs/core';
-
-vi.mock('./image.generated', async () => {
-  const { tensorAsBase64, getImageAsTensor, ...rest } = await vi.importActual('./image.generated') as typeof imageGenerated;
-  return {
-    ...rest,
-    tensorAsBase64: vi.fn(tensorAsBase64),
-    getImageAsTensor: vi.fn(getImageAsTensor),
-  };
-});
 
 vi.mock('./dependencies.generated', async () => {
   const { tf, ...dependencies } = await vi.importActual('./dependencies.generated') as typeof dependenciesGenerated;
@@ -68,7 +54,7 @@ describe('padInput', () => {
   });
 
   afterEach(() => {
-    vi.mocked(isFixedShape4D).mockClear();
+    vi.clearAllMocks();
   });
 
   it('just returns the input if inputSize is less than the shape of the tensor', () => {
@@ -131,7 +117,7 @@ describe('trimInput', () => {
 
 describe('scaleOutput', () => {
   afterEach(() => {
-    isValidRange.mockClear();
+    vi.clearAllMocks();
   });
 
   it('returns tensor unchanged if input shape is not valid', () => tf.tidy(() => {
@@ -175,7 +161,7 @@ describe('getWidthAndHeight', () => {
 
 describe('scaleIncomingPixels', () => {
   beforeEach(() => {
-    isValidRange.mockClear();
+    vi.clearAllMocks();
   });
 
   it('returns unadulterated incoming pixels if given no range', () => tf.tidy(() => {
@@ -208,9 +194,7 @@ describe('tensorAsClampedArray', () => {
 
 describe('concatTensors', () => {
   beforeEach(() => {
-    tensorAsBase64.mockClear();
-    getImageAsTensor.mockClear();
-    isTensor.mockClear();
+    vi.clearAllMocks();
   });
   it('concats two tensors together', () => {
     const a: tfn.Tensor3D = tf.tensor(

--- a/packages/upscalerjs/src/tensor-utils.ts
+++ b/packages/upscalerjs/src/tensor-utils.ts
@@ -17,9 +17,6 @@ import {
   nonNullable,
 } from './utils';
 import {
-  Input,
-} from './image.generated';
-import {
   Coordinate,
 } from './types';
 
@@ -86,7 +83,7 @@ export const tensorAsClampedArray = (tensor: tf.Tensor3D): Uint8Array | Float32A
 // if given a tensor, we copy it; otherwise, we pass input through unadulterated
 // this allows us to safely dispose of memory ourselves without having to manage
 // what input is in which format
-export const getCopyOfInput = (input: Input): Input => (isTensor(input) ? input.clone() : input);
+export function getCopyOfInput<T>(input: T): T { return (isTensor(input) ? input.clone() : input); }
 
 export function concatTensors<T extends tf.Tensor3D | tf.Tensor4D> (tensors: Array<T | undefined>, axis = 0): T {
   const definedTensors: Array<tf.Tensor3D | tf.Tensor4D> = tensors.filter(nonNullable);

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -88,6 +88,8 @@ export type CheckValidEnvironment<T> = (input: T, opts: {
   output?: ResultFormat;
   progressOutput?: ResultFormat;
 }) => void;
+export type GetImageAsTensor<T> = (input: T) => Promise<tf.Tensor4D>;
+export type TensorAsBase64 = (tensor: tf.Tensor3D) => string;
 
 export type Coordinate = [number, number];
 

--- a/packages/upscalerjs/src/upscale.test.ts
+++ b/packages/upscalerjs/src/upscale.test.ts
@@ -14,11 +14,6 @@ import {
   AbortError,
 } from './errors-and-warnings';
 import {
-  checkValidEnvironment,
-  tensorAsBase64,
-  getImageAsTensor,
-} from './image.generated';
-import {
   wrapGenerator,
   warn,
 } from './utils';
@@ -41,15 +36,6 @@ vi.mock('./utils', async () => {
   };
 });
 
-vi.mock('./image.generated', async () => {
-  const { tensorAsBase64, getImageAsTensor, checkValidEnvironment, ...rest } = await vi.importActual('./image.generated') as typeof imageGenerated;
-  return {
-    ...rest,
-    tensorAsBase64: vi.fn(tensorAsBase64),
-    getImageAsTensor: vi.fn(getImageAsTensor),
-    checkValidEnvironment: vi.fn(checkValidEnvironment),
-  };
-});
 vi.mock('@upscalerjs/core', async () => {
   const { isFourDimensionalTensor, isTensor, ...rest } = await vi.importActual('@upscalerjs/core') as typeof core;
   return {
@@ -149,6 +135,8 @@ describe('predict', () => {
       modelPackage,
       {
         originalImageSize: [null, ...tensor.shape],
+      }, {
+        tensorAsBase64: () => '',
       })
     );
     expect(spy).toHaveBeenCalledWith(
@@ -172,6 +160,8 @@ describe('predict', () => {
         originalImageSize: [null, ...tensor.shape],
         patchSize: 1,
         padding: 0,
+      }, {
+        tensorAsBase64: () => '',
       }
     ));
     checkStartingTensorAgainstUpscaledTensor(tensor, result);
@@ -190,6 +180,8 @@ describe('predict', () => {
         originalImageSize: [null, ...tensor.shape],
         patchSize: 1,
         padding: 0,
+      }, {
+        tensorAsBase64: () => '',
       }
     ));
     checkStartingTensorAgainstUpscaledTensor(tensor, result);
@@ -210,6 +202,8 @@ describe('predict', () => {
           originalImageSize: tensor.shape,
           patchSize,
           padding: 0,
+        }, {
+          tensorAsBase64: () => '',
         })
     );
     expect(progress).toHaveBeenCalledWith(0.25);
@@ -221,7 +215,6 @@ describe('predict', () => {
 
   it('should invoke progress callback with percent and slice', async () => {
     const mockResponse = 'foobarbaz1';
-    tensorAsBase64.mockImplementation(() => mockResponse);
     const tensor = getTensor(4, 4).expandDims(0) as tf.Tensor4D;
     const patchSize = 2;
     const progress = vi.fn((_1: any, _2: any) => { });
@@ -236,6 +229,8 @@ describe('predict', () => {
         originalImageSize: tensor.shape,
         patchSize,
         padding: 0,
+      }, {
+        tensorAsBase64: () => mockResponse,
       })
     );
     expect(progress).toHaveBeenCalledWith(0.25, mockResponse, expect.objectContaining({ row: 0, col: 0, }));
@@ -247,7 +242,6 @@ describe('predict', () => {
 
   it('should invoke progress callback with percent and a rescaled slice if given an output range', async () => {
     const mockResponse = 'foobarbaz1';
-    tensorAsBase64.mockImplementation(() => mockResponse);
     const tensor = getTensor(4, 4).expandDims(0) as tf.Tensor4D;
     const patchSize = 2;
     const progress = vi.fn((_1: any, _2: any) => { });
@@ -267,6 +261,8 @@ describe('predict', () => {
       patchSize,
       padding: 0,
       originalImageSize: tensor.shape,
+    }, {
+      tensorAsBase64: () => mockResponse,
     })
     );
     expect(progress).toHaveBeenCalledWith(0.25, mockResponse, expect.objectContaining({ row: 0, col: 0, }));
@@ -278,7 +274,6 @@ describe('predict', () => {
 
   it('should invoke progress callback with percent, slice, and slice data', async () => {
     const mockResponse = 'foobarbaz1';
-    tensorAsBase64.mockImplementation(() => mockResponse);
     const tensor = getTensor(4, 4).expandDims(0) as tf.Tensor4D;
     const patchSize = 2;
     const progress = vi.fn<ReturnType<MultiArgStringProgress>, Parameters<MultiArgStringProgress>>((_1: any, _2: any, _3: any) => { });
@@ -293,6 +288,8 @@ describe('predict', () => {
         patchSize,
         padding: 0,
         originalImageSize: tensor.shape,
+      }, {
+        tensorAsBase64: () => mockResponse,
       })
     );
     expect(progress).toHaveBeenCalledWith(0.25, mockResponse, expect.objectContaining({ row: 0, col: 0, }));
@@ -328,6 +325,8 @@ describe('predict', () => {
         originalImageSize: tensor.shape,
         patchSize,
         padding: 0,
+      }, {
+        tensorAsBase64: () => '',
       })
     );
     expect(progress).toHaveBeenCalledWith(0.5,
@@ -376,6 +375,8 @@ describe('predict', () => {
         originalImageSize: tensor.shape,
         patchSize,
         padding: 0,
+      }, {
+        tensorAsBase64: () => '',
       })
     );
     expect(progress).toHaveBeenCalledWith(0.5,
@@ -424,6 +425,8 @@ describe('predict', () => {
         originalImageSize: tensor.shape,
         patchSize,
         padding: 0,
+      }, {
+        tensorAsBase64: () => '',
       })
     );
     expect(progress).toHaveBeenCalledWith(0.5,
@@ -459,6 +462,8 @@ describe('predict', () => {
       modelPackage,
       {
         originalImageSize: tensor.shape,
+      }, {
+        tensorAsBase64: () => '',
       })
     );
     expect(warn).toHaveBeenCalledWith(WARNING_PROGRESS_WITHOUT_PATCH_SIZE);
@@ -474,6 +479,8 @@ describe('predict', () => {
         progressOutput: 'base64',
       }, modelPackage, {
         originalImageSize: tensor.shape,
+      }, {
+        tensorAsBase64: () => '',
       });
 
 
@@ -516,6 +523,8 @@ describe('predict', () => {
         {
           originalImageSize: tensor.shape,
           patchSize,
+        }, {
+          tensorAsBase64: () => '',
         }
       );
 
@@ -588,8 +597,7 @@ describe('predict', () => {
 
 describe('upscale', () => {
   afterEach(() => {
-    getImageAsTensor.mockClear();
-    tensorAsBase64.mockClear();
+    vi.clearAllMocks();
   });
 
   it('should return a base64 string by default', async () => {
@@ -603,20 +611,22 @@ describe('upscale', () => {
         [4, 4, 4,],
       ],
     ]);
-    getImageAsTensor.mockImplementation(async () => img.expandDims(0) as tf.Tensor4D);
     const model = {
       predict: vi.fn(() => tf.ones([1, 2, 2, 3,])),
       inputs: [{
         shape: [null, null, null, 3],
       }]
     } as unknown as tf.LayersModel;
-    tensorAsBase64.mockImplementation(() => 'foobarbaz4');
+    const tensorAsBase64 = vi.fn().mockImplementation(() => 'foobarbaz4');
     const result = await wrapGenerator(upscale(img, {
       output: 'base64',
       progressOutput: 'base64',
     }, {
       model,
       modelDefinition: { scale: 2, } as ModelDefinition,
+    }, {
+      getImageAsTensor: () => Promise.resolve(img.expandDims(0) as tf.Tensor4D),
+      tensorAsBase64,
     }));
     expect(result).toEqual('foobarbaz4');
     expect(tensorAsBase64).toHaveBeenCalled();
@@ -633,14 +643,12 @@ describe('upscale', () => {
         [4, 4, 4,],
       ],
     ]);
-    getImageAsTensor.mockImplementation(async () => img.expandDims(0) as tf.Tensor4D);
     const model = {
       predict: vi.fn(() => tf.ones([1, 2, 2, 3,])),
       inputs: [{
         shape: [null, null, null, 3],
       }]
     } as unknown as tf.LayersModel;
-    tensorAsBase64.mockImplementation(() => 'foobarbaz4');
     const result = await wrapGenerator(upscale(img, {
       output: 'base64',
       progressOutput: 'base64',
@@ -650,6 +658,9 @@ describe('upscale', () => {
         scale: 2,
         outputRange: [0, 1],
       } as ModelDefinition,
+    }, {
+      getImageAsTensor: () => Promise.resolve(img.expandDims(0) as tf.Tensor4D),
+      tensorAsBase64: () => 'foobarbaz4',
     }));
     expect(result).toEqual('foobarbaz4');
   });
@@ -665,7 +676,6 @@ describe('upscale', () => {
         [4, 4, 4,],
       ],
     ]);
-    getImageAsTensor.mockImplementation(async () => img.expandDims(0) as tf.Tensor4D);
     const upscaledTensor = tf.ones([1, 2, 2, 3,]);
     const model = {
       predict: vi.fn(() => upscaledTensor.clone()),
@@ -677,6 +687,9 @@ describe('upscale', () => {
     const result = await wrapGenerator(upscale(img, { output: 'tensor', progressOutput: 'tensor', }, {
       model,
       modelDefinition: { scale: 2, } as ModelDefinition,
+    }, {
+      getImageAsTensor: () => Promise.resolve(img.expandDims(0) as tf.Tensor4D),
+      tensorAsBase64: () => 'foobarbaz5',
     }));
     if (typeof result === 'string') {
       throw new Error('Unexpected string type');
@@ -686,13 +699,8 @@ describe('upscale', () => {
 });
 
 describe('cancellableUpscale', () => {
-  beforeEach(() => {
-    checkValidEnvironment.mockImplementation(() => true);
-  });
-
   it('is able to cancel an in-flight request', async () => {
     const img: tf.Tensor4D = tf.ones([4, 4, 3,]).expandDims(0);
-    getImageAsTensor.mockImplementation(async () => img);
     const scale = 2;
     const patchSize = 2;
     const model = {
@@ -725,6 +733,10 @@ describe('cancellableUpscale', () => {
       model,
       modelDefinition: { scale, } as ModelDefinition,
       signal: new AbortController().signal,
+    }, {
+      checkValidEnvironment: () => true,
+      getImageAsTensor: () => Promise.resolve(img),
+      tensorAsBase64: () => 'foo',
     }))
       .rejects
       .toThrow(AbortError);
@@ -736,7 +748,6 @@ describe('cancellableUpscale', () => {
 
   it('is able to cancel an in-flight request with an internal signal', async () => {
     const img: tf.Tensor4D = tf.ones([4, 4, 3,]).expandDims(0);
-    getImageAsTensor.mockImplementation(async () => img);
     const scale = 2;
     const patchSize = 2;
     const model = {
@@ -768,6 +779,10 @@ describe('cancellableUpscale', () => {
       model,
       modelDefinition: { scale, } as ModelDefinition,
       signal: controller.signal,
+    }, {
+      checkValidEnvironment: () => true,
+      getImageAsTensor: () => Promise.resolve(img),
+      tensorAsBase64: () => 'foo',
     }))
       .rejects
       .toThrow(AbortError);
@@ -779,10 +794,7 @@ describe('cancellableUpscale', () => {
 
   it('returns processed pixels', async () => {
     const mockResponse = 'foobarbaz6';
-    tensorAsBase64.mockImplementation(() => mockResponse);
-    checkValidEnvironment.mockImplementation(() => true);
     const img: tf.Tensor4D = tf.ones([4, 4, 3,]).expandDims(0);
-    getImageAsTensor.mockImplementation(async () => img);
     const controller = new AbortController();
     const scale = 2;
     const patchSize = 2;
@@ -804,6 +816,10 @@ describe('cancellableUpscale', () => {
       model,
       modelDefinition: { scale, } as ModelDefinition,
       signal: controller.signal,
+    }, {
+      checkValidEnvironment: () => true,
+      getImageAsTensor: () => Promise.resolve(img),
+      tensorAsBase64: () => mockResponse,
     });
     expect(result).toEqual(mockResponse);
   });
@@ -811,8 +827,7 @@ describe('cancellableUpscale', () => {
 
 describe('executeModel', () => {
   afterEach(() => {
-    isTensor.mockClear();
-    isFourDimensionalTensor.mockClear();
+    vi.clearAllMocks();
   });
   it('throws if the model does not return a valid tensor', () => {
     const model = {

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -29,7 +29,12 @@ import { getUpscaleOptions, } from './args.generated';
 import { loadModel, } from './loadModel.generated';
 import { cancellableWarmup, } from './warmup';
 import { cancellableUpscale, } from './upscale';
-import type { Input, } from './image.generated';
+import {
+  getImageAsTensor,
+  tensorAsBase64,
+  checkValidEnvironment,
+  Input,
+} from './image.generated';
 import type { ModelDefinitionObjectOrFn, } from '@upscalerjs/core';
 import { getModel, } from './model-utils';
 
@@ -146,6 +151,10 @@ export class Upscaler {
     return cancellableUpscale(image, getUpscaleOptions(options), {
       ...modelPackage,
       signal: this._abortController.signal,
+    }, {
+      checkValidEnvironment,
+      getImageAsTensor,
+      tensorAsBase64,
     });
   }
 


### PR DESCRIPTION
Step 2 of deprecating the scaffolding build step.

Remove some generated image imports.