### PR TITLE
Update upscaler types to not import generated deps

### DIFF
--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -56,6 +56,7 @@ const getTensorFromInput = async (input: Input): Promise<Tensor3D | Tensor4D> =>
 
 export type Input = Tensor3D | Tensor4D | string | tf.FromPixelsInputs['pixels'];
 export const getImageAsTensor: GetImageAsTensor<typeof tf, Input> = async (
+  _tf,
   input,
 ) => {
   const tensor = await getTensorFromInput(input);

--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -83,7 +83,7 @@ export const isHTMLImageElement = (pixels: Input): pixels is HTMLImageElement =>
   }
 };
 
-export const tensorAsBase64: TensorAsBase64 = (tensor) => {
+export const tensorAsBase64: TensorAsBase64 = (_tf, tensor) => {
   const arr = tensorAsClampedArray(tensor);
   const [height, width, ] = tensor.shape;
   const imageData = new ImageData(width, height);

--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -1,4 +1,5 @@
 import { tf, } from './dependencies.generated';
+import type { Tensor3D, Tensor4D, Tensor, } from '@tensorflow/tfjs-core';
 import { CheckValidEnvironment, GetImageAsTensor, TensorAsBase64, } from './types';
 import { tensorAsClampedArray, } from './tensor-utils';
 import { isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from '@upscalerjs/core';
@@ -19,7 +20,7 @@ export const getEnvironmentDisallowsBase64 = () => new Error([
   `For more information, see ${ERROR_ENVIRONMENT_DISALLOWS_BASE64_URL}.`,
 ].join('\n'));
 
-export const getInvalidTensorError = (input: tf.Tensor): Error => new Error(
+export const getInvalidTensorError = (input: Tensor): Error => new Error(
   [
     `Unsupported dimensions for incoming pixels: ${input.shape.length}.`,
     'Only 3 or 4 rank tensors are supported.',
@@ -38,9 +39,9 @@ export const loadImage = (src: string): Promise<HTMLImageElement> => new Promise
   img.onerror = () => reject(getInvalidImageError());
 });
 
-const fromPixels = (input: Exclude<Input, string | tf.Tensor>) => tf.browser.fromPixelsAsync(input);
+const fromPixels = (input: Exclude<Input, string | Tensor>) => tf.browser.fromPixelsAsync(input);
 
-const getTensorFromInput = async (input: Input): Promise<tf.Tensor3D | tf.Tensor4D> => {
+const getTensorFromInput = async (input: Input): Promise<Tensor3D | Tensor4D> => {
   if (isTensor(input)) {
     return input;
   }
@@ -53,8 +54,8 @@ const getTensorFromInput = async (input: Input): Promise<tf.Tensor3D | tf.Tensor
   return fromPixels(input);
 };
 
-export type Input = tf.Tensor3D | tf.Tensor4D | string | tf.FromPixelsInputs['pixels'];
-export const getImageAsTensor: GetImageAsTensor<Input> = async (
+export type Input = Tensor3D | Tensor4D | string | tf.FromPixelsInputs['pixels'];
+export const getImageAsTensor: GetImageAsTensor<typeof tf, Input> = async (
   input,
 ) => {
   const tensor = await getTensorFromInput(input);
@@ -62,7 +63,7 @@ export const getImageAsTensor: GetImageAsTensor<Input> = async (
   if (isThreeDimensionalTensor(tensor)) {
     // https://github.com/tensorflow/tfjs/issues/1125
     /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
-    const expandedTensor = tensor.expandDims(0) as tf.Tensor4D;
+    const expandedTensor = tensor.expandDims(0) as Tensor4D;
     tensor.dispose();
     return expandedTensor;
   }

--- a/packages/upscalerjs/src/image.node.test.ts
+++ b/packages/upscalerjs/src/image.node.test.ts
@@ -51,17 +51,17 @@ describe('Image', () => {
 
   describe('getImageAsTensor', () => {
     it('handles a uint array', async () => {
-      const result = await getImageAsTensor(image);
+      const result = await getImageAsTensor(tf, image);
       expect(result.shape).toEqual([1,16,16,3,]);
     });
 
     it('handles a buffer', async () => {
-      const result = await getImageAsTensor(image);
+      const result = await getImageAsTensor(tf, image);
       expect(result.shape).toEqual([1,16,16,3,]);
     });
 
     it('handles a local string path to a file', async () => {
-      const result = await getImageAsTensor(FLOWER);
+      const result = await getImageAsTensor(tf, FLOWER);
       expect(result.shape).toEqual([1,16,16,3,]);
     });
 
@@ -69,7 +69,7 @@ describe('Image', () => {
       const height = 3;
       const width = 2;
       const input = getTensor(height, width).expandDims(0) as tf.Tensor4D;
-      const result = await getImageAsTensor(input);
+      const result = await getImageAsTensor(tf, input);
       expect(result.shape).toEqual([1,height, width, 3,]);
     });
 
@@ -77,14 +77,14 @@ describe('Image', () => {
       const height = 3;
       const width = 2;
       const input = getTensor(height, width);
-      const result = await getImageAsTensor(input);
+      const result = await getImageAsTensor(tf, input);
       expect(result.shape).toEqual([1,height, width, 3,]);
     });
 
     it('handles an invalid (too small) tensor input', async () => {
       vi.mocked(hasValidChannels).mockReturnValue(true);
       const input = tf.tensor([[1,],]);
-      await expect(() => getImageAsTensor(input as any))
+      await expect(() => getImageAsTensor(tf, input as any))
         .rejects
         .toThrow(getInvalidTensorError(input));
     });
@@ -92,13 +92,13 @@ describe('Image', () => {
     it('handles an invalid (too large) tensor input', async () => {
       vi.mocked(hasValidChannels).mockReturnValue(true);
       const input = tf.tensor([[[[[1,],],],],]);
-      await expect(() => getImageAsTensor(input as tf.Tensor3D))
+      await expect(() => getImageAsTensor(tf, input as tf.Tensor3D))
         .rejects
         .toThrow(getInvalidTensorError(input));
     });
 
     it('handles invalid input', async () => {
-      await expect(() => getImageAsTensor(123 as any))
+      await expect(() => getImageAsTensor(tf, 123 as any))
         .rejects
         .toThrow(getInvalidInput(123));
     });
@@ -108,7 +108,7 @@ describe('Image', () => {
         throw new Error(`no such file or directory, open ${filename}`);
       })
       const filename = 'foo';
-      await expect(() => getImageAsTensor(filename))
+      await expect(() => getImageAsTensor(tf, filename))
         .rejects
         .toThrow(getInvalidImageSrcInput(filename));
     });

--- a/packages/upscalerjs/src/image.node.test.ts
+++ b/packages/upscalerjs/src/image.node.test.ts
@@ -118,6 +118,6 @@ describe('Image', () => {
 describe('tensorAsBase64', () => {
   it('returns a tensor as base64', () => {
     const t: tf.Tensor3D = tf.ones([2,2,3]);
-    expect(tensorAsBase64(t)).toEqual('AQEB/wEBAf8BAQH/AQEB/w==');
+    expect(tensorAsBase64(tf, t)).toEqual('AQEB/wEBAf8BAQH/AQEB/w==');
   });
 });

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -62,6 +62,7 @@ export type Input = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
 
 /* eslint-disable @typescript-eslint/require-await */
 export const getImageAsTensor: GetImageAsTensor<typeof tf, Input> = async (
+  _tf,
   input,
 ) => {
   const tensor = getTensorFromInput(input);

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -61,7 +61,7 @@ const getTensorFromInput = (input: Input): tf.Tensor3D | tf.Tensor4D => {
 export type Input = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
 
 /* eslint-disable @typescript-eslint/require-await */
-export const getImageAsTensor: GetImageAsTensor<Input> = async (
+export const getImageAsTensor: GetImageAsTensor<typeof tf, Input> = async (
   input,
 ) => {
   const tensor = getTensorFromInput(input);

--- a/packages/upscalerjs/src/image.node.ts
+++ b/packages/upscalerjs/src/image.node.ts
@@ -83,7 +83,7 @@ export const getImageAsTensor: GetImageAsTensor<Input> = async (
   throw getInvalidTensorError(tensor);
 };
 
-export const tensorAsBase64: TensorAsBase64 = (tensor) => {
+export const tensorAsBase64: TensorAsBase64 = (_tf, tensor) => {
   const arr = tensorAsClampedArray(tensor);
   return Buffer.from(arr).toString('base64');
 };

--- a/packages/upscalerjs/src/image.playwright.browser.test.ts
+++ b/packages/upscalerjs/src/image.playwright.browser.test.ts
@@ -44,7 +44,7 @@ describe('Image', async () => {
 
   describe('getImageAsTensor', () => {
     it('loads an Image() if given a string as input', async () => {
-      const tensor = await getImageAsTensor(FLOWER_SMALL);
+      const tensor = await getImageAsTensor(tf, FLOWER_SMALL);
       const result = await tf.browser.toPixels(tensor.squeeze() as tf.Tensor3D)
       expect(result.length).to.equal(expectedArray.length);
       for (let i = 0; i < result.length; i++) {
@@ -54,14 +54,14 @@ describe('Image', async () => {
     });
 
     it.only('handles a rejected Image() if given a string as input', () => {
-      return getImageAsTensor('foobar')
+      return getImageAsTensor(tf, 'foobar')
         .then(() => { throw new Error('was not supposed to succeed'); })
         .catch(m => expect(m.message).to.equal(getInvalidImageError().message));
     });
 
     it('reads a given Image() directly', async () => {
       const img = await loadImage(FLOWER_SMALL);
-      const tensor = await getImageAsTensor(img);
+      const tensor = await getImageAsTensor(tf, img);
       const result = await tf.browser.toPixels(tensor.squeeze() as tf.Tensor3D)
       expect(result.length).to.equal(expectedArray.length);
       for (let i = 0; i < result.length; i++) {
@@ -72,21 +72,21 @@ describe('Image', async () => {
 
     it('reads a rank 4 tensor directly without manipulation', async () => {
       const input: tf.Tensor4D = tf.tensor([[[[1,],],],]);
-      const tensor = await getImageAsTensor(input);
+      const tensor = await getImageAsTensor(tf, input);
       expect(input.dataSync()).to.deep.equal(tensor.dataSync());
       input.dispose();
     });
 
     it('reads a rank 3 tensor and expands to rank 4', async () => {
       const input: tf.Tensor3D = tf.tensor([[[1,],],]);
-      const tensor = await getImageAsTensor(input);
+      const tensor = await getImageAsTensor(tf, input);
       expect(tensor.shape).to.deep.equal([1,1,1,1,]);
       input.dispose();
     });
 
     it('handles an invalid (too small) tensor input', async () => {
       const input = tf.tensor([[1,],]);
-      return getImageAsTensor(input as any)
+      return getImageAsTensor(tf, input as any)
         .then(() => { throw new Error('was not supposed to succeed'); })
         .catch(m => {
           input.dispose();
@@ -96,7 +96,7 @@ describe('Image', async () => {
 
     it('handles an invalid (too large) tensor input', async () => {
       const input = tf.tensor([[[[[1,],],],],]);
-      return getImageAsTensor(input as any)
+      return getImageAsTensor(tf, input as any)
         .then(() => { throw new Error('was not supposed to succeed'); })
         .catch(m => {
           input.dispose();

--- a/packages/upscalerjs/src/types.browser.ts
+++ b/packages/upscalerjs/src/types.browser.ts
@@ -1,3 +1,4 @@
-import { tf, } from './dependencies.generated';
+import type { Tensor3D, Tensor4D, } from '@tensorflow/tfjs-core';
+import type { FromPixelsInputs, } from '@tensorflow/tfjs';
 
-export type Input = tf.Tensor3D | tf.Tensor4D | string | tf.FromPixelsInputs['pixels'];
+export type Input = Tensor3D | Tensor4D | string | FromPixelsInputs['pixels'];

--- a/packages/upscalerjs/src/types.node.ts
+++ b/packages/upscalerjs/src/types.node.ts
@@ -1,3 +1,3 @@
-import { tf, } from './dependencies.generated';
+import type { Tensor3D, Tensor4D, } from '@tensorflow/tfjs-core';
 
-export type Input = tf.Tensor3D | tf.Tensor4D | string | Uint8Array | Buffer;
+export type Input = Tensor3D | Tensor4D | string | Uint8Array | Buffer;

--- a/packages/upscalerjs/src/types.ts
+++ b/packages/upscalerjs/src/types.ts
@@ -1,5 +1,6 @@
-import { tf, } from './dependencies.generated';
-import type { ModelDefinitionObjectOrFn, ModelDefinition, } from '@upscalerjs/core';
+import type { Tensor3D, Tensor4D, } from '@tensorflow/tfjs-core';
+import type { LayersModel, layers, } from '@tensorflow/tfjs-layers';
+import type { TF, GraphModel, ModelDefinitionObjectOrFn, ModelDefinition, } from '@upscalerjs/core';
 
 export type WarmupSizesByPatchSize = {
   patchSize: number;
@@ -30,7 +31,7 @@ export interface SliceData {
   }
 }
 export type MultiArgStringProgress = (amount: number, slice: string, sliceData: SliceData) => void;
-export type MultiArgTensorProgress = (amount: number, slice: tf.Tensor3D, sliceData: SliceData) => void;
+export type MultiArgTensorProgress = (amount: number, slice: Tensor3D, sliceData: SliceData) => void;
 export type SingleArgProgress = (amount: number) => void;
 export type Progress = SingleArgProgress | MultiArgStringProgress | MultiArgTensorProgress;
 
@@ -73,14 +74,14 @@ export interface PrivateUpscaleArgs extends Omit<UpscaleArgs, 'output' | 'progre
   progressOutput: BASE64 | TENSOR;
 }
 
-export type Layer = tf.layers.Layer;
+export type Layer = layers.Layer;
 
 export interface ModelPackage {
-  model: tf.LayersModel | tf.GraphModel;
+  model: LayersModel | GraphModel;
   modelDefinition: ParsedModelDefinition;
 }
 
-export type YieldedIntermediaryValue = undefined | tf.Tensor4D | tf.Tensor3D | Array<tf.Tensor3D | tf.Tensor4D | undefined>;
+export type YieldedIntermediaryValue = undefined | Tensor4D | Tensor3D | Array<Tensor3D | Tensor4D | undefined>;
 
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface WarmupArgs extends SharedArgs {}
@@ -88,8 +89,8 @@ export type CheckValidEnvironment<T> = (input: T, opts: {
   output?: ResultFormat;
   progressOutput?: ResultFormat;
 }) => void;
-export type GetImageAsTensor<T> = (input: T) => Promise<tf.Tensor4D>;
-export type TensorAsBase64 = (tensor: tf.Tensor3D) => string;
+export type GetImageAsTensor<T extends TF, I> = (tf: T, input: I) => Promise<Tensor4D>;
+export type TensorAsBase64 = (tf: TF, tensor: Tensor3D) => string;
 
 export type Coordinate = [number, number];
 

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -138,7 +138,7 @@ export async function* processPixels(
               progress(percent, squeezedTensor, sliceData);
             } else {
               // because we are returning a string, we can safely dispose of our tensor
-              const src = tensorAsBase64(squeezedTensor);
+              const src = tensorAsBase64(tf, squeezedTensor);
               squeezedTensor.dispose();
               progress(percent, src, sliceData);
             }

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -232,7 +232,7 @@ export async function* upscale<I>(
   }: Pick<InternalConfig<I>, 'getImageAsTensor' | 'tensorAsBase64'>
 ): AsyncGenerator<YieldedIntermediaryValue, string | tf.Tensor3D> {
   const parsedInput = getCopyOfInput<I>(input);
-  const startingPixels = await getImageAsTensor(parsedInput);
+  const startingPixels = await getImageAsTensor(tf, parsedInput);
   yield startingPixels;
 
   const imageSize = startingPixels.shape;

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -285,14 +285,14 @@ export async function* upscale<I>(
     return upscaledPixels;
   }
 
-  const base64Src = tensorAsBase64(upscaledPixels);
+  const base64Src = tensorAsBase64(tf, upscaledPixels);
   upscaledPixels.dispose();
   return base64Src;
 };
 
 interface InternalConfig<I> {
   checkValidEnvironment: CheckValidEnvironment<I>;
-  getImageAsTensor: GetImageAsTensor<I>,
+  getImageAsTensor: GetImageAsTensor<typeof tf, I>,
   tensorAsBase64: TensorAsBase64,
 }
 


### PR DESCRIPTION
Slices off a small piece of the https://github.com/thekevinscott/UpscalerJS/pull/1155 PR, which is inexplicably failing CI, to help narrow down the failing CI and merge the full PR