### PR TITLE
Update islayersmodel to not import from generated deps

### DIFF
--- a/packages/upscalerjs/src/isLayersModel.test.ts
+++ b/packages/upscalerjs/src/isLayersModel.test.ts
@@ -8,6 +8,6 @@ describe('isLayersModel', () => {
     const model = tfn.sequential();
     model.add(tfn.layers.dense({units: 1, inputShape: [1]}));
     model.compile({optimizer: 'sgd', loss: 'meanSquaredError'});
-    expect(isLayersModel(model)).toEqual(true);
+    expect(isLayersModel(tfn, model)).toEqual(true);
   });
 });

--- a/packages/upscalerjs/src/isLayersModel.ts
+++ b/packages/upscalerjs/src/isLayersModel.ts
@@ -1,3 +1,4 @@
-import { tf, } from './dependencies.generated';
+import type { LayersModel, } from '@tensorflow/tfjs-layers';
+import type { TF, GraphModel, } from '@upscalerjs/core';
 
-export const isLayersModel = (model: tf.LayersModel | tf.GraphModel): model is tf.LayersModel => model instanceof tf.LayersModel;
+export const isLayersModel = (tf: TF, model: LayersModel | GraphModel): model is LayersModel => model instanceof tf.LayersModel;

--- a/packages/upscalerjs/src/model-utils.test.ts
+++ b/packages/upscalerjs/src/model-utils.test.ts
@@ -214,7 +214,7 @@ describe('model-utils', () => {
           }],
         }
       } as ModelPackage;
-      expect(() => parsePatchAndInputShapes(modelPackage, { patchSize, padding: 8 }, [null, 9, 9, 3])).toThrow(GET_INVALID_PATCH_SIZE(patchSize));
+      expect(() => parsePatchAndInputShapes(tfn, modelPackage, { patchSize, padding: 8 }, [null, 9, 9, 3])).toThrow(GET_INVALID_PATCH_SIZE(patchSize));
       expect(warn).not.toHaveBeenCalled();
     });
 
@@ -231,7 +231,7 @@ describe('model-utils', () => {
         },
         model,
       };
-      parsePatchAndInputShapes(modelPackage, { patchSize: 9 }, [null, 9, 9, 3]);
+      parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 9 }, [null, 9, 9, 3]);
       expect(warn).toHaveBeenCalledWith(WARNING_UNDEFINED_PADDING);
       expect(warn).toHaveBeenCalledTimes(1);
     });
@@ -246,7 +246,7 @@ describe('model-utils', () => {
           }],
         }
       } as ModelPackage;
-      expect(() => parsePatchAndInputShapes(modelPackage, { patchSize, padding }, [null, 9, 9, 3])).toThrow(GET_INVALID_PATCH_SIZE_AND_PADDING(patchSize, padding));
+      expect(() => parsePatchAndInputShapes(tfn, modelPackage, { patchSize, padding }, [null, 9, 9, 3])).toThrow(GET_INVALID_PATCH_SIZE_AND_PADDING(patchSize, padding));
     });
 
     describe('Input size', () => {
@@ -258,7 +258,7 @@ describe('model-utils', () => {
             }],
           },
         } as ModelPackage;
-        parsePatchAndInputShapes(modelPackage, { patchSize: 9, padding: 2 }, [null, 9, 9, 3]);
+        parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 9, padding: 2 }, [null, 9, 9, 3]);
         expect(warn).toHaveBeenCalledWith(WARNING_INPUT_SIZE_AND_PATCH_SIZE);
         expect(warn).toHaveBeenCalledTimes(1);
       });
@@ -271,7 +271,7 @@ describe('model-utils', () => {
             }],
           },
         } as ModelPackage;
-        expect(() => parsePatchAndInputShapes(modelPackage, { patchSize: 9, padding: 1 }, [null, 9, 9, 3])).toThrowError(MODEL_INPUT_SIZE_MUST_BE_SQUARE);
+        expect(() => parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 9, padding: 1 }, [null, 9, 9, 3])).toThrowError(MODEL_INPUT_SIZE_MUST_BE_SQUARE);
         expect(warn).toHaveBeenCalledWith(WARNING_INPUT_SIZE_AND_PATCH_SIZE);
       });
 
@@ -283,7 +283,7 @@ describe('model-utils', () => {
             }],
           },
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, { patchSize: 3, padding: 1 }, [null, 9, 9, 3])).toEqual({
+        expect(parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 3, padding: 1 }, [null, 9, 9, 3])).toEqual({
           patchSize: 9,
           padding: 1,
           modelInputShape: [null, 9, 9, 3],
@@ -308,7 +308,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {}, [null, 4, 4, 3])).toEqual({
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {}, [null, 4, 4, 3])).toEqual({
           patchSize: undefined,
           padding: undefined,
           modelInputShape: [null, 4, 4, 3],
@@ -330,7 +330,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {}, [null, 3, 3, 3])).toEqual({
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {}, [null, 3, 3, 3])).toEqual({
           patchSize: undefined,
           padding: undefined,
           modelInputShape: [null, 4, 4, 3],
@@ -352,7 +352,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {
           patchSize: 8,
         }, [null, 3, 3, 3])).toEqual({
           patchSize: 8,
@@ -377,7 +377,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {
           patchSize: 7,
         }, [null, 3, 3, 3])).toEqual({
           patchSize: 8,
@@ -403,7 +403,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {
           patchSize: 4,
           padding: 1,
         }, [null, 3, 3, 3])).toEqual({
@@ -428,7 +428,7 @@ describe('model-utils', () => {
           },
           modelDefinition,
         } as ModelPackage;
-        expect(parsePatchAndInputShapes(modelPackage, {
+        expect(parsePatchAndInputShapes(tfn, modelPackage, {
           patchSize: 4,
           padding: 1,
         }, [null, 3, 3, 3])).toEqual({
@@ -454,7 +454,7 @@ describe('model-utils', () => {
         },
         model,
       };
-      expect(parsePatchAndInputShapes(modelPackage, { patchSize: 9, padding: 1 }, [null, 9, 9, 3])).toEqual({
+      expect(parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 9, padding: 1 }, [null, 9, 9, 3])).toEqual({
         patchSize: 9,
         padding: 1,
         modelInputShape: undefined,
@@ -471,7 +471,7 @@ describe('model-utils', () => {
         },
         modelDefinition: {},
       } as ModelPackage;
-      parsePatchAndInputShapes(modelPackage, { patchSize: 9 }, [null, 9, 9, 3]);
+      parsePatchAndInputShapes(tfn, modelPackage, { patchSize: 9 }, [null, 9, 9, 3]);
       expect(warn).toHaveBeenCalledWith(WARNING_UNDEFINED_PADDING);
     });
 
@@ -480,7 +480,7 @@ describe('model-utils', () => {
   describe('getModelInputShape', () => {
     it('returns layers model input shape if it is a layers model', () => {
       vi.mocked(isLayersModel.isLayersModel).mockImplementation(() => true);
-      expect(getModelInputShape({
+      expect(getModelInputShape(tfn, {
         model: {
           layers: [{
             batchInputShape: [1, 2, 3, 4],
@@ -491,7 +491,7 @@ describe('model-utils', () => {
 
     it('returns graph model input shape if it is a layers model', () => {
       vi.mocked(isLayersModel.isLayersModel).mockImplementation(() => false);
-      expect(getModelInputShape({
+      expect(getModelInputShape(tfn, {
         model: {
           inputs: [{
             shape: [1, 2, 3, 4],
@@ -503,7 +503,7 @@ describe('model-utils', () => {
     it('throws if a model returns a non rank 4 shape', () => {
       vi.mocked(isShape4D).mockImplementation(() => false);
       vi.mocked(isLayersModel.isLayersModel).mockImplementation(() => true);
-      expect(() => getModelInputShape({
+      expect(() => getModelInputShape(tfn, {
         model: {
           layers: [{
             batchInputShape: [1, 2, 3, 4, 5],

--- a/packages/upscalerjs/src/model-utils.ts
+++ b/packages/upscalerjs/src/model-utils.ts
@@ -65,15 +65,15 @@ export function loadTfModel<M extends ModelType, R = Promise<M extends 'graph' ?
   return tf.loadLayersModel(modelPath) as R;
 }
 
-const getBatchInputShape = (model: LayersModel | GraphModel): unknown => {
-  if (isLayersModel(model)) {
+const getBatchInputShape = (tf: TF, model: LayersModel | GraphModel): unknown => {
+  if (isLayersModel(tf, model)) {
     return model.layers[0].batchInputShape;
   }
   return model.inputs[0].shape;
 };
 
-export const getModelInputShape = ({ model, }: ModelPackage): Shape4D => {
-  const batchInputShape = getBatchInputShape(model);
+export const getModelInputShape = (tf: TF, { model, }: ModelPackage): Shape4D => {
+  const batchInputShape = getBatchInputShape(tf, model);
   if (!isShape4D(batchInputShape)) {
     throw new Error(ERROR_WITH_MODEL_INPUT_SHAPE(batchInputShape));
   }
@@ -97,14 +97,15 @@ export const getPatchSizeAsMultiple = (divisibilityFactor: number, patchSize: nu
  * - if a model has not defined its own input size, return the given user variables (which may be undefined)
  */
 type ParsePatchAndInputShapes = (
+  tf: TF,
   modelPackage: ModelPackage,
   args: UpscaleArgs,
   imageSize: FixedShape4D,
 ) => {
   modelInputShape?: Shape4D;
 } & Pick<UpscaleArgs, 'patchSize' | 'padding'>;
-export const parsePatchAndInputShapes: ParsePatchAndInputShapes = (modelPackage, { patchSize, padding, }, imageSize) => {
-  const modelInputShape = getModelInputShape(modelPackage);
+export const parsePatchAndInputShapes: ParsePatchAndInputShapes = (tf, modelPackage, { patchSize, padding, }, imageSize) => {
+  const modelInputShape = getModelInputShape(tf, modelPackage);
   if (patchSize !== undefined) {
     if (patchSize <= 0) {
       throw GET_INVALID_PATCH_SIZE(patchSize);

--- a/packages/upscalerjs/src/upscale.ts
+++ b/packages/upscalerjs/src/upscale.ts
@@ -241,7 +241,7 @@ export async function* upscale<I>(
 
   // retrieve the patch size and padding. If the model definition has defined its own input shape,
   // then that input shape will override the user's variables.
-  const { patchSize, padding, modelInputShape, } = parsePatchAndInputShapes(modelPackage, args, imageSize);
+  const { patchSize, padding, modelInputShape, } = parsePatchAndInputShapes(tf, modelPackage, args, imageSize);
 
   const preprocessedPixels = processAndDisposeOfTensor(
     tf,

--- a/packages/upscalerjs/src/upscaler.ts
+++ b/packages/upscalerjs/src/upscaler.ts
@@ -13,7 +13,9 @@
  *
  * @module UpscalerJS
  */
-import { DefaultUpscalerModel, tf, } from './dependencies.generated';
+import { tf, } from './dependencies.generated';
+import type { Tensor3D, } from '@tensorflow/tfjs-core';
+import DefaultUpscalerModel from '@upscalerjs/default-model';
 import type {
   UpscalerOptions,
   ModelPackage,
@@ -44,6 +46,11 @@ import { getModel, } from './model-utils';
 const DEFAULT_MODEL: ModelDefinitionObjectOrFn = DefaultUpscalerModel;
 
 export class Upscaler {
+  /**
+   * @hidden
+   */
+  private tf = tf;
+
   /**
    * @hidden
    */
@@ -84,7 +91,7 @@ export class Upscaler {
     this._opts = {
       ...opts,
     };
-    this._model = loadModel(getModel(tf, this._opts.model || DEFAULT_MODEL));
+    this._model = loadModel(getModel(this.tf, this._opts.model || DEFAULT_MODEL));
     this.ready = new Promise((resolve, reject) => {
       this._model.then(() => cancellableWarmup(this._model, (this._opts.warmupSizes || []), undefined, {
         signal: this._abortController.signal,
@@ -122,7 +129,7 @@ export class Upscaler {
   public async execute(
     image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output: TENSOR; progress?: MultiArgStringProgress; progressOutput: BASE64 },
-  ): Promise<tf.Tensor3D>;
+  ): Promise<Tensor3D>;
   public async execute(
     image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: BASE64; progress?: MultiArgTensorProgress; progressOutput: TENSOR },
@@ -130,7 +137,7 @@ export class Upscaler {
   public async execute(
     image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output: TENSOR; progress?: MultiArgTensorProgress; progressOutput?: unknown },
-  ): Promise<tf.Tensor3D>;
+  ): Promise<Tensor3D>;
   public async execute(
     image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: BASE64; progress?: MultiArgStringProgress; progressOutput?: unknown },
@@ -138,7 +145,7 @@ export class Upscaler {
   public async execute(
     image: Input,
     options: Omit<UpscaleArgs, 'output' | 'progress' | 'progressOutput'> & { output?: TENSOR | BASE64; progress?: MultiArgStringProgress | MultiArgTensorProgress; progressOutput?: unknown },
-  ): Promise<tf.Tensor3D | string>;
+  ): Promise<Tensor3D | string>;
   public async execute(
     image: Input,
   ): Promise<string>;
@@ -213,7 +220,7 @@ export class Upscaler {
     await this.ready;
     const { model, modelDefinition, } = await this._model;
     if (modelDefinition.teardown) {
-      await modelDefinition.teardown(tf);
+      await modelDefinition.teardown(this.tf);
     }
     model.dispose();
   };


### PR DESCRIPTION
Slices off a small piece of the https://github.com/thekevinscott/UpscalerJS/pull/1155 PR, which is inexplicably failing CI, to help narrow down the failing CI and merge the full PR