### PR TITLE
Refactor image functions to not import tf as dep

### DIFF
--- a/packages/upscalerjs/src/image.browser.ts
+++ b/packages/upscalerjs/src/image.browser.ts
@@ -1,5 +1,5 @@
-import { tf, } from './dependencies.generated';
-import type { Tensor3D, Tensor4D, Tensor, } from '@tensorflow/tfjs-core';
+import * as tf from '@tensorflow/tfjs';
+import type { Tensor, Tensor3D, Tensor4D, } from '@tensorflow/tfjs-core';
 import { CheckValidEnvironment, GetImageAsTensor, TensorAsBase64, } from './types';
 import { tensorAsClampedArray, } from './tensor-utils';
 import { isString, isFourDimensionalTensor, isThreeDimensionalTensor, isTensor, } from '@upscalerjs/core';
@@ -41,7 +41,11 @@ export const loadImage = (src: string): Promise<HTMLImageElement> => new Promise
 
 const fromPixels = (input: Exclude<Input, string | Tensor>) => tf.browser.fromPixelsAsync(input);
 
-const getTensorFromInput = async (input: Input): Promise<Tensor3D | Tensor4D> => {
+const getTensorFromInput = async (
+  input: Input, 
+   /* eslint-disable @typescript-eslint/no-unused-vars */
+  _tf: typeof tf,
+): Promise<Tensor3D | Tensor4D> => {
   if (isTensor(input)) {
     return input;
   }
@@ -56,10 +60,10 @@ const getTensorFromInput = async (input: Input): Promise<Tensor3D | Tensor4D> =>
 
 export type Input = Tensor3D | Tensor4D | string | tf.FromPixelsInputs['pixels'];
 export const getImageAsTensor: GetImageAsTensor<typeof tf, Input> = async (
-  _tf,
+  tf,
   input,
 ) => {
-  const tensor = await getTensorFromInput(input);
+  const tensor = await getTensorFromInput(input, tf);
 
   if (isThreeDimensionalTensor(tensor)) {
     // https://github.com/tensorflow/tfjs/issues/1125
@@ -102,7 +106,9 @@ export const tensorAsBase64: TensorAsBase64 = (tf, tensor) => {
 
 const checkIfValidEnvironment = (errFn: () => Error) => {
   try {
-    (new Image() && 'createElement' in document) === true; // skipcq: JS-0354
+    if ((new Image() && 'createElement' in document) !== true) { // skipcq: JS-0354
+      throw errFn();
+    }
   } catch(err) {
     throw errFn();
   }

--- a/packages/upscalerjs/src/image.node.test.ts
+++ b/packages/upscalerjs/src/image.node.test.ts
@@ -8,7 +8,7 @@ import {
   getInvalidTensorError,
   getInvalidImageSrcInput,
 } from './image.node';
-import { tf } from './dependencies.generated';
+import * as tf from '@tensorflow/tfjs-node';
 import {
   hasValidChannels,
 } from '@upscalerjs/core'
@@ -84,7 +84,7 @@ describe('Image', () => {
     it('handles an invalid (too small) tensor input', async () => {
       vi.mocked(hasValidChannels).mockReturnValue(true);
       const input = tf.tensor([[1,],]);
-      await expect(() => getImageAsTensor(tf, input as any))
+      await expect(() => getImageAsTensor(tf, input as tf.Tensor3D))
         .rejects
         .toThrow(getInvalidTensorError(input));
     });

--- a/packages/upscalerjs/src/image.playwright.browser.test.ts
+++ b/packages/upscalerjs/src/image.playwright.browser.test.ts
@@ -53,7 +53,7 @@ describe('Image', async () => {
       }
     });
 
-    it.only('handles a rejected Image() if given a string as input', () => {
+    it('handles a rejected Image() if given a string as input', () => {
       return getImageAsTensor(tf, 'foobar')
         .then(() => { throw new Error('was not supposed to succeed'); })
         .catch(m => expect(m.message).to.equal(getInvalidImageError().message));
@@ -86,7 +86,7 @@ describe('Image', async () => {
 
     it('handles an invalid (too small) tensor input', async () => {
       const input = tf.tensor([[1,],]);
-      return getImageAsTensor(tf, input as any)
+      return getImageAsTensor(tf, input as tf.Tensor3D)
         .then(() => { throw new Error('was not supposed to succeed'); })
         .catch(m => {
           input.dispose();


### PR DESCRIPTION
Slices off a small piece of the https://github.com/thekevinscott/UpscalerJS/pull/1155 PR, which is inexplicably failing CI, to help narrow down the failing CI and merge the full PR