### PR TITLE
Update progress example to allow UI to update on progress

### DIFF
--- a/examples/progress/index.js
+++ b/examples/progress/index.js
@@ -15,6 +15,7 @@ button.onclick = () => {
     .upscale(img, {
       patchSize: 2,
       padding: 2,
+      awaitNextFrame: true,
       progress: (amount) => {
         progressLabel.innerText = `${(amount * 100).toFixed(2)}%`;
       },

--- a/scripts/start-example.ts
+++ b/scripts/start-example.ts
@@ -88,7 +88,7 @@ const getArgs = async (): Promise<Answers> => {
     skipUpscalerBuild: { type: 'boolean' },
   }).help().argv;
 
-  const exampleDirectory = await getString('Which hdf5 model do you want to build?', argv._[0]);
+  const exampleDirectory = await getString('Which example do you want to start?', argv._[0]);
 
   return { exampleDirectory, skipUpscalerBuild: argv.skipUpscalerBuild };
 }


### PR DESCRIPTION
Fix #1118

Allow the UI to have time to updating by setting the `awaitNextFrame` flag to true.

(If leveraging web workers or something that moved the computation off the main UI thread, this would not be required.)