### PR TITLE
Clean up package.json structures

### DIFF
--- a/models/default-model/package.json
+++ b/models/default-model/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/index.min.js",
       "require": "./dist/cjs/models/default-model/src/cjs.js",
       "import": "./dist/esm/models/default-model/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "dist/esm/models/default-model/src/index.js",
   "types": "dist/esm/models/default-model/src/index.d.ts",

--- a/models/esrgan-legacy/package.json
+++ b/models/esrgan-legacy/package.json
@@ -47,7 +47,8 @@
       "umd": "./dist/umd/models/esrgan-legacy/src/gans/index.min.js",
       "require": "./dist/cjs/models/esrgan-legacy/src/gans/cjs.js",
       "import": "./dist/esm/models/esrgan-legacy/src/gans/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/esrgan-legacy/src/index.js",
   "types": "./dist/esm/models/esrgan-legacy/src/index.d.ts",

--- a/models/esrgan-medium/package.json
+++ b/models/esrgan-medium/package.json
@@ -42,7 +42,8 @@
       "umd": "./dist/umd/models/esrgan-medium/src/x8/index.min.js",
       "require": "./dist/cjs/models/esrgan-medium/src/x8/cjs.js",
       "import": "./dist/esm/models/esrgan-medium/src/x8/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/esrgan-medium/src/index.js",
   "types": "./dist/esm/models/esrgan-medium/src/index.d.ts",

--- a/models/esrgan-slim/package.json
+++ b/models/esrgan-slim/package.json
@@ -42,7 +42,8 @@
       "umd": "./dist/umd/models/esrgan-slim/src/x8/index.min.js",
       "require": "./dist/cjs/models/esrgan-slim/src/x8/cjs.js",
       "import": "./dist/esm/models/esrgan-slim/src/x8/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/esrgan-slim/src/index.js",
   "types": "./dist/esm/models/esrgan-slim/src/index.d.ts",

--- a/models/esrgan-thick/package.json
+++ b/models/esrgan-thick/package.json
@@ -42,7 +42,8 @@
       "umd": "./dist/umd/models/esrgan-thick/src/x8/index.min.js",
       "require": "./dist/cjs/models/esrgan-thick/src/x8/cjs.js",
       "import": "./dist/esm/models/esrgan-thick/src/x8/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/esrgan-thick/src/index.js",
   "types": "./dist/esm/models/esrgan-thick/src/index.d.ts",

--- a/models/maxim-deblurring/package.json
+++ b/models/maxim-deblurring/package.json
@@ -19,14 +19,15 @@
   },
   "exports": {
     ".": {
-      "umd": "./dist/umd/models/maxim-deblurring/src/umd.min.js",
-      "require": "./dist/cjs/models/maxim-deblurring/src/cjs.js",
-      "import": "./dist/esm/models/maxim-deblurring/src/index.js"
-    }
+      "types": "./dist/esm/models/maxim-deblurring/src/index.d.ts",
+      "import": "./dist/esm/models/maxim-deblurring/src/index.js",
+      "require": "./dist/cjs/models/maxim-deblurring/src/cjs.js"
+    },
+    "./package.json": "./package.json"
   },
+  "main": "./dist/cjs/models/maxim-deblurring/src/cjs.js",
   "module": "./dist/esm/models/maxim-deblurring/src/index.js",
   "types": "./dist/esm/models/maxim-deblurring/src/index.d.ts",
-  "umd:main": "./dist/umd/models/maxim-deblurring/src/umd.min.js",
   "scripts": {
     "lint": "wireit",
     "prepublishOnly": "wireit",

--- a/models/maxim-dehazing-indoor/package.json
+++ b/models/maxim-dehazing-indoor/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-dehazing-indoor/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-dehazing-indoor/src/cjs.js",
       "import": "./dist/esm/models/maxim-dehazing-indoor/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-dehazing-indoor/src/index.js",
   "types": "./dist/esm/models/maxim-dehazing-indoor/src/index.d.ts",

--- a/models/maxim-dehazing-outdoor/package.json
+++ b/models/maxim-dehazing-outdoor/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-dehazing-outdoor/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-dehazing-outdoor/src/cjs.js",
       "import": "./dist/esm/models/maxim-dehazing-outdoor/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-dehazing-outdoor/src/index.js",
   "types": "./dist/esm/models/maxim-dehazing-outdoor/src/index.d.ts",

--- a/models/maxim-denoising/package.json
+++ b/models/maxim-denoising/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-denoising/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-denoising/src/cjs.js",
       "import": "./dist/esm/models/maxim-denoising/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-denoising/src/index.js",
   "types": "./dist/esm/models/maxim-denoising/src/index.d.ts",

--- a/models/maxim-deraining/package.json
+++ b/models/maxim-deraining/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-deraining/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-deraining/src/cjs.js",
       "import": "./dist/esm/models/maxim-deraining/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-deraining/src/index.js",
   "types": "./dist/esm/models/maxim-deraining/src/index.d.ts",

--- a/models/maxim-enhancement/package.json
+++ b/models/maxim-enhancement/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-enhancement/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-enhancement/src/cjs.js",
       "import": "./dist/esm/models/maxim-enhancement/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-enhancement/src/index.js",
   "types": "./dist/esm/models/maxim-enhancement/src/index.d.ts",

--- a/models/maxim-experiments/package.json
+++ b/models/maxim-experiments/package.json
@@ -62,7 +62,8 @@
     "./retouching/64": {
       "require": "./dist/cjs/models/maxim-experiments/src/retouching/64.js",
       "import": "./dist/esm/models/maxim-experiments/src/retouching/64.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "lint": "wireit",

--- a/models/maxim-retouching/package.json
+++ b/models/maxim-retouching/package.json
@@ -22,7 +22,8 @@
       "umd": "./dist/umd/models/maxim-retouching/src/umd.min.js",
       "require": "./dist/cjs/models/maxim-retouching/src/cjs.js",
       "import": "./dist/esm/models/maxim-retouching/src/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "module": "./dist/esm/models/maxim-retouching/src/index.js",
   "types": "./dist/esm/models/maxim-retouching/src/index.d.ts",

--- a/models/pixel-upsampler/package.json
+++ b/models/pixel-upsampler/package.json
@@ -24,7 +24,8 @@
       "umd": "./dist/umd/x4.min.js",
       "require": "./dist/cjs/models/pixel-upsampler/src/x4/cjs.js",
       "import": "./dist/esm/models/pixel-upsampler/src/x4/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "umd:main": "dist/umd/umd.min.js",
   "scripts": {

--- a/packages/upscalerjs/package.json
+++ b/packages/upscalerjs/package.json
@@ -14,7 +14,8 @@
     ".": {
       "types": "./dist/browser/esm/upscalerjs/src/browser/esm/index.d.ts",
       "import": "./dist/browser/esm/upscalerjs/src/browser/esm/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": ">=16.0"


### PR DESCRIPTION
Adds self-referential `package.json`, removes UMD definition which is invalid, add `types` and `main` entries.