### PR TITLE
Enable Netlify docs hosting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,13 +1,14 @@
-# [build.environment]
-#   NPM_FLAGS = "--version"
-# [build]
-#   base = "docs/"
-#   command = "pip install --upgrade pip && echo '>>>>>>>>' && pnpm i --store=node_modules/.pnpm-store && pnpm run build"
-#   # command = "npx pnpm i --store=node_modules/.pnpm-store && npx pnpm run build"
-#   # publish = "build"
-#   # ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ."
-[[headers]]
-  for = "/*"
-  [headers.values]
-    Cross-Origin-Embedder-Policy = "require-corp"
-    # Cross-Origin-Opener-Policy = "same-origin"
+# Build runs from repo root (no `base`) so the pnpm workspace + wireit
+# cross-package deps (models/*, packages/upscalerjs, internals/scripts) resolve.
+[build]
+  command = "pnpm install --frozen-lockfile && pnpm --filter @upscalerjs/docs build"
+  publish = "docs/build"
+
+[build.environment]
+  NODE_VERSION = "16"          # parity with .github/workflows/docs.yml (EOL; bump separately)
+  PNPM_VERSION = "8"           # parity with .github/actions/setup-pnpm
+  GIT_LFS_SKIP_SMUDGE = "1"    # docs build needs no model weights; skip the 140MB LFS pull
+
+# COEP/COOP removed: WebGL/CPU demo, no SharedArrayBuffer/WASM threads. The header
+# was orphaned legacy (#1014, 2023) tied to no feature, and require-corp only risks
+# blocking cross-origin subresources (jsdelivr model, Pixabay images, Shoelace, Plausible).

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,10 +5,5 @@
   publish = "docs/build"
 
 [build.environment]
-  NODE_VERSION = "16"          # parity with .github/workflows/docs.yml (EOL; bump separately)
-  PNPM_VERSION = "8"           # parity with .github/actions/setup-pnpm
+  NODE_VERSION = "24"          # parity with .github/workflows/docs.yml
   GIT_LFS_SKIP_SMUDGE = "1"    # docs build needs no model weights; skip the 140MB LFS pull
-
-# COEP/COOP removed: WebGL/CPU demo, no SharedArrayBuffer/WASM threads. The header
-# was orphaned legacy (#1014, 2023) tied to no feature, and require-corp only risks
-# blocking cross-origin subresources (jsdelivr model, Pixabay images, Shoelace, Plausible).


### PR DESCRIPTION
Spike on Netlify docs hosting, potentially enabling preview deploys