### PR TITLE
Auto-rebase Renovate PRs when behind main

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
   "schedule": ["* * * * 1"],
   "minimumReleaseAge": "3 days",
   "internalChecksFilter": "strict",
+  "rebaseWhen": "behind-base-branch",
   "lockFileMaintenance": { "enabled": true, "schedule": ["* * * * 1"] },
   "packageRules": [
     {


### PR DESCRIPTION
rebaseWhen: behind-base-branch — removes the manual rebase checkbox; open Renovate PRs rebase and re-run CI automatically after each merge to main.