### PR TITLE
Group Renovate major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,17 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non-major dependencies"
+    },
+    {
+      "groupName": "docusaurus 3 migration",
+      "matchPackageNames": ["/docusaurus/", "react", "react-dom", "/^@types\\/react/", "@mdx-js/react", "react-dropzone", "react-icons", "react-markdown"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    },
+    {
+      "groupName": "low-risk tooling majors",
+      "matchPackageNames": ["chalk", "commander", "concurrently", "date-fns", "nock", "ejs", "sass-loader", "typedoc-plugin-markdown", "@algolia/client-search", "@cloudflare/workers-types"],
+      "matchUpdateTypes": ["major"]
     }
   ],
   "vulnerabilityAlerts": { "minimumReleaseAge": "0" }


### PR DESCRIPTION
Parks the docusaurus 3 ecosystem (incl. react 19, which docusaurus 2 blocks) behind dashboard approval as
  one migration group; batches low-risk tooling majors into a single PR. High-risk majors (typescript, vitest, puppeteer, @types/node, inquirer, yargs, dotenv, pixelmatch) stay individual per #1340.