### PR TITLE
Run CI on Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [24]
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@v7

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,10 +26,10 @@ jobs:
       #   with:
       #     detached: true
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Lint'
         run: 'pnpm lint'
@@ -44,10 +44,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Unit Tests / Vite'
         working-directory: ./packages/upscalerjs
@@ -70,10 +70,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Unit Tests / Playwright'
         working-directory: ./packages/upscalerjs
@@ -99,10 +99,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Unit Tests'
         working-directory: ./packages/upscalerjs
@@ -126,10 +126,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Unit Tests'
         working-directory: ./packages/shared
@@ -147,10 +147,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Unit Tests'
         working-directory: ./internals
@@ -195,10 +195,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
@@ -227,10 +227,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Integration Tests'
         run: pnpm test:integration:clientside
@@ -249,10 +249,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
@@ -275,10 +275,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3
@@ -299,10 +299,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Integration Tests'
         run: pnpm test:integration:model:serverside
@@ -317,10 +317,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       - name: 'Memory Leak Tests'
         run: pnpm test:integration:memory-leaks
@@ -337,10 +337,10 @@ jobs:
         with:
           lfs: 'true'
 
-      - name: 'Setup PNPM with Node 22'
+      - name: 'Setup PNPM with Node 24'
         uses: ./.github/actions/setup-pnpm
         with:
-          node-version: 22
+          node-version: 24
 
       # - name: Setup tmate session
       #   uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
node-version 22 → 24 across tests.yml and the docs matrix. Engines already allow <25 (#1370); pnpm already pins useNodeVersion
  24.18.0.