### PR TITLE
Pull chalk out of the low-risk majors group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,8 +19,13 @@
     },
     {
       "groupName": "low-risk tooling majors",
-      "matchPackageNames": ["chalk", "commander", "concurrently", "date-fns", "nock", "ejs", "sass-loader", "typedoc-plugin-markdown", "@algolia/client-search", "@cloudflare/workers-types"],
+      "matchPackageNames": ["commander", "concurrently", "date-fns", "nock", "ejs", "sass-loader", "typedoc-plugin-markdown", "@algolia/client-search", "@cloudflare/workers-types"],
       "matchUpdateTypes": ["major"]
+    },
+    {
+      "matchPackageNames": ["chalk"],
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     }
   ],
   "vulnerabilityAlerts": { "minimumReleaseAge": "0" }


### PR DESCRIPTION
chalk 5+ drops its TS namespace and is ESM-only; it breaks internals/common and needs a code change. Parked behind
  dashboard approval; rest of the group can land.