### PR TITLE
Allow @parcel/watcher build scripts

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ overrides:
   webpack: 5.96.1
 
 allowBuilds:
+  '@parcel/watcher': true
   '@tensorflow/tfjs-node': true
   '@tensorflow/tfjs-node-gpu': true
   core-js: true


### PR DESCRIPTION
New transitive via the wireit bump; ERR_PNPM_IGNORED_BUILDS currently fails install on every
  Renovate PR. Prebuilt binaries ship as optional deps.