### PR TITLE
fix(ci): rebuild tfjs-node-gpu's native addon after the bundler install

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -60,6 +60,12 @@ runs:
         PUPPETEER_SKIP_DOWNLOAD: 'true'
       run: timeout 600 pnpm install --frozen-lockfile
 
+    # tfjs-node's install script exits 0 even when it produces no native addon.
+    # Fail here, naming the missing path, instead of minutes later in a test job.
+    - name: Verify tfjs-node native addons
+      shell: bash
+      run: node ${{ github.action_path }}/verify-native-addons.mjs
+
     - name: Install Chrome for Puppeteer
       # Runs only for jobs that need a browser (job-level PUPPETEER_SKIP_DOWNLOAD
       # unset). Single invocation of puppeteer's own installer -> no concurrent

--- a/.github/actions/setup-pnpm/verify-native-addons.mjs
+++ b/.github/actions/setup-pnpm/verify-native-addons.mjs
@@ -1,0 +1,28 @@
+// @tensorflow/tfjs-node ships its native addon outside the npm tarball and
+// fetches it in its own `install` script. That script runs node-pre-gyp via
+// `cp.exec` without forwarding stdout/stderr, so when the addon is not produced
+// the script still exits 0 and pnpm reports `Done` -- there is nothing in the
+// log to see. The failure surfaces minutes later as a vitest failure on
+// `require('@tensorflow/tfjs-node')`, in a job that looks unrelated to install.
+//
+// Asserting here costs ~0.3s and turns that into an install-time failure naming
+// the exact path that is missing.
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+
+for (const pkg of ['@tensorflow/tfjs-node', '@tensorflow/tfjs-node-gpu']) {
+  const dir = path.dirname(require.resolve(`${pkg}/package.json`));
+  const addon = path.join(dir, 'lib', 'napi-v8', 'tfjs_binding.node');
+  if (!fs.existsSync(addon)) {
+    console.error(`Missing native addon for ${pkg}: ${addon}`);
+    process.exit(1);
+  }
+}
+
+// Existence is not enough: an ABI mismatch or a truncated download only shows up
+// on load. tfjs-node-gpu is deliberately not loaded here -- it needs a CUDA
+// runtime the runners do not have, so the file check above is as far as it goes.
+require('@tensorflow/tfjs-node');

--- a/internals/common/src/npm.ts
+++ b/internals/common/src/npm.ts
@@ -75,12 +75,33 @@ export const pnpmInstall = async (cwd: string, _opts = {}) => {
   verbose(`${command.join(' ')} in ${cwd}`);
   await runPackageCommand(command, cwd, 'pnpm');
 
-  // we need to rebuild tfjs since --ignore-scripts above skips it.
+  // The bundler work dirs live under `tmp/bundlers/**`, which pnpm-workspace.yaml
+  // lists as workspace packages, so the install above is *workspace-wide*.
+  // `--no-frozen-lockfile` re-resolves the graph and can change peer suffixes
+  // (`_supports-color@x`); a changed suffix is a changed depPath, so pnpm creates
+  // a new virtual store directory and repoints node_modules at it. That directory
+  // is hard linked from the content-addressable store, which holds only what was
+  // in the npm tarball -- and `--ignore-scripts` means the `install` script that
+  // fetches `lib/napi-v8/tfjs_binding.node` never runs. Both tfjs node packages
+  // therefore lose their native addon here and have to be rebuilt.
+  //
+  // Both, not just the CPU one: -gpu was omitted when this rebuild was first
+  // added, which is why `Integration / Serverside` failed on `loads a model with
+  // node-gpu` while every tfjs-node test passed.
+  //
   // --workspace-concurrency=1: parallel rebuilds of the same package across
   // projects race in the side-effects cache and corrupt store-hardlinked
-  // files (ERR_PNPM_JSON_PARSE on tfjs-node's package.json).
+  // files (ERR_PNPM_JSON_PARSE on tfjs-node's package.json). Kept as a backstop
+  // even though pnpm-workspace.yaml now sets `sideEffectsCache: false`.
   // (--config. form: pnpm rebuild rejects the bare --workspace-concurrency flag)
-  await runPackageCommand(['pnpm', 'rebuild', '-r', '--config.workspace-concurrency=1', '@tensorflow/tfjs-node'], cwd, 'pnpm');
+  await runPackageCommand([
+    'pnpm',
+    'rebuild',
+    '-r',
+    '--config.workspace-concurrency=1',
+    '@tensorflow/tfjs-node',
+    '@tensorflow/tfjs-node-gpu',
+  ], cwd, 'pnpm');
 };
 
 export const runPNPMCommand = (

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,16 @@ packages:
 overrides:
   webpack: 5.96.1
 
+# pnpm caches the *result* of a package's build scripts in the store and replays
+# that snapshot into any project sharing the store, skipping the build script
+# entirely. @tensorflow/tfjs-node fetches its native addon
+# (lib/napi-v8/tfjs_binding.node) during its own `install` script, so a snapshot
+# taken from a build that produced no addon is indistinguishable from a good one
+# -- and is then replayed forever. CI restores the pnpm store from cache with
+# `restore-keys`, so one bad build keeps every subsequent run broken. Rebuilding
+# from scratch costs a few seconds; a poisoned store costs days.
+sideEffectsCache: false
+
 allowBuilds:
   '@parcel/watcher': true
   '@tensorflow/tfjs-node': true


### PR DESCRIPTION
Fixes the \`Integration / Serverside\` failure on #1423 (\`loads a model with node-gpu\`).

  \`ca1e4ce6\` (#1400) added a \`pnpm rebuild\` to repair the native addon the bundler's workspace install strips, but listed only \`@tensorflow/tfjs-node\`. \`-gpu\` was never rebuilt — which is why every tfjs-node test passed and only the
  node-gpu one failed.

  - \`internals/common/src/npm.ts\` — add \`-gpu\` to the rebuild list. The fix.
  - \`pnpm-workspace.yaml\` — \`sideEffectsCache: false\`. Independent bug, same symptom: pnpm replays a cached build-script result, and CI restores the store with \`restore-keys\`, so one bad build persists.
  - \`.github/actions/setup-pnpm/\` — assert both addons right after install, so a silent install fails at install time instead of minutes later.

  Supersedes the unmerged \`fix/tfjs-node-native-addon\` branch, which predates #1400 and would regress its \`-r\` / \`--config.workspace-concurrency=1\` race guard.